### PR TITLE
Isolate DuckDB elm code

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,27 +1,20 @@
-module Config exposing (apiHost)
+module Config exposing (..)
 
-
-env =
-    Production
-
-
-
---LocalDev
-
-
-type Env
-    = LocalDev
-    | LocalGunicorn
-    | Production
+import Env
 
 
 apiHost =
-    case env of
-        LocalDev ->
+    case Env.mode of
+        Env.Production ->
+            "https://fir-api.robsoko.tech"
+
+        _ ->
             "http://localhost:8000"
 
-        LocalGunicorn ->
-            "http://localhost:8080"
 
-        Production ->
-            "https://fir-api.robsoko.tech"
+
+-- develop against local dev-fastapi
+--"http://localhost:8080"
+-- develop against gunicorn server
+--"https://fir-api.robsoko.tech"
+-- develop against prod

--- a/src/DuckDb.elm
+++ b/src/DuckDb.elm
@@ -274,4 +274,4 @@ owningRefDecoder =
 
 
 
--- begin region: fir-api HTTP utility functions
+-- end region: fir-api HTTP utility functions

--- a/src/Evergreen/Migrate/V6.elm
+++ b/src/Evergreen/Migrate/V6.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V6 exposing (..)
+
+import Evergreen.V5.Types as Old
+import Evergreen.V6.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgUnchanged
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgUnchanged

--- a/src/Evergreen/V6/Array2D.elm
+++ b/src/Evergreen/V6/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V6.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V6/Bridge.elm
+++ b/src/Evergreen/V6/Bridge.elm
@@ -1,0 +1,5 @@
+module Evergreen.V6.Bridge exposing (..)
+
+
+type ToBackend
+    = NoopToBackend

--- a/src/Evergreen/V6/DuckDb.elm
+++ b/src/Evergreen/V6/DuckDb.elm
@@ -1,0 +1,65 @@
+module Evergreen.V6.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias ColumnName =
+    String
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias OwningRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type DuckDbRef
+    = View OwningRef
+    | Table OwningRef
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias DuckDbColumn =
+    { name : ColumnName
+    , owningRef : DuckDbRef
+    , type_ : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbColumnDescription =
+    { name : ColumnName
+    , owningRef : DuckDbRef
+    , type_ : String
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    }
+
+
+type alias DuckDbTableRefsResponse =
+    { refs : List TableName
+    }

--- a/src/Evergreen/V6/DuckDb.elm
+++ b/src/Evergreen/V6/DuckDb.elm
@@ -15,15 +15,15 @@ type alias TableName =
     String
 
 
-type alias OwningRef =
+type alias DuckDbRef =
     { schemaName : SchemaName
     , tableName : TableName
     }
 
 
-type DuckDbRef
-    = View OwningRef
-    | Table OwningRef
+type DuckDbRef_
+    = View DuckDbRef
+    | Table DuckDbRef
 
 
 type Val
@@ -37,7 +37,7 @@ type Val
 
 type alias PersistedDuckDbColumn =
     { name : ColumnName
-    , owningRef : DuckDbRef
+    , parentRef : DuckDbRef_
     , dataType : String
     , vals : List (Maybe Val)
     }
@@ -62,7 +62,7 @@ type alias DuckDbQueryResponse =
 
 type alias PersistedDuckDbColumnDescription =
     { name : ColumnName
-    , owningRef : DuckDbRef
+    , parentRef : DuckDbRef_
     , dataType : String
     }
 
@@ -83,6 +83,6 @@ type alias DuckDbMetaResponse =
     }
 
 
-type alias DuckDbTableRefsResponse =
-    { refs : List OwningRef
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
     }

--- a/src/Evergreen/V6/DuckDb.elm
+++ b/src/Evergreen/V6/DuckDb.elm
@@ -35,12 +35,24 @@ type Val
     | Unknown
 
 
-type alias DuckDbColumn =
+type alias PersistedDuckDbColumn =
     { name : ColumnName
     , owningRef : DuckDbRef
-    , type_ : String
+    , dataType : String
     , vals : List (Maybe Val)
     }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
 
 
 type alias DuckDbQueryResponse =
@@ -48,11 +60,22 @@ type alias DuckDbQueryResponse =
     }
 
 
-type alias DuckDbColumnDescription =
+type alias PersistedDuckDbColumnDescription =
     { name : ColumnName
     , owningRef : DuckDbRef
-    , type_ : String
+    , dataType : String
     }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
 
 
 type alias DuckDbMetaResponse =
@@ -61,5 +84,5 @@ type alias DuckDbMetaResponse =
 
 
 type alias DuckDbTableRefsResponse =
-    { refs : List TableName
+    { refs : List OwningRef
     }

--- a/src/Evergreen/V6/Gen/Model.elm
+++ b/src/Evergreen/V6/Gen/Model.elm
@@ -1,0 +1,16 @@
+module Evergreen.V6.Gen.Model exposing (..)
+
+import Evergreen.V6.Gen.Params.Home_
+import Evergreen.V6.Gen.Params.NotFound
+import Evergreen.V6.Gen.Params.Sheet
+import Evergreen.V6.Gen.Params.VegaLite
+import Evergreen.V6.Pages.Sheet
+import Evergreen.V6.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Home_ Evergreen.V6.Gen.Params.Home_.Params
+    | Sheet Evergreen.V6.Gen.Params.Sheet.Params Evergreen.V6.Pages.Sheet.Model
+    | VegaLite Evergreen.V6.Gen.Params.VegaLite.Params Evergreen.V6.Pages.VegaLite.Model
+    | NotFound Evergreen.V6.Gen.Params.NotFound.Params

--- a/src/Evergreen/V6/Gen/Msg.elm
+++ b/src/Evergreen/V6/Gen/Msg.elm
@@ -1,0 +1,9 @@
+module Evergreen.V6.Gen.Msg exposing (..)
+
+import Evergreen.V6.Pages.Sheet
+import Evergreen.V6.Pages.VegaLite
+
+
+type Msg
+    = Sheet Evergreen.V6.Pages.Sheet.Msg
+    | VegaLite Evergreen.V6.Pages.VegaLite.Msg

--- a/src/Evergreen/V6/Gen/Pages.elm
+++ b/src/Evergreen/V6/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V6.Gen.Pages exposing (..)
+
+import Evergreen.V6.Gen.Model
+import Evergreen.V6.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V6.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V6.Gen.Msg.Msg

--- a/src/Evergreen/V6/Gen/Params/Home_.elm
+++ b/src/Evergreen/V6/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V6.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V6/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V6/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V6.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V6/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V6/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V6.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V6/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V6/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V6.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V6/Pages/Sheet.elm
+++ b/src/Evergreen/V6/Pages/Sheet.elm
@@ -62,14 +62,14 @@ type alias Model =
     , uiMode : UiMode
     , duckDbResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbQueryResponse
     , duckDbMetaResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbMetaResponse
-    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbTableRefsResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbRefsResponse
     , userSqlText : String
     , fileUploadStatus : FileUploadStatus
     , nowish : Maybe Time.Posix
     , viewport : Maybe Browser.Dom.Viewport
     , renderStatus : RenderStatus
-    , selectedTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
-    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.DuckDbRef
     }
 
 
@@ -83,8 +83,8 @@ type Msg
     | GotResizeEvent Int Int
     | KeyWentDown KeyCode
     | KeyReleased KeyCode
-    | UserSelectedTableRef Evergreen.V6.DuckDb.OwningRef
-    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.OwningRef
+    | UserSelectedTableRef Evergreen.V6.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.DuckDbRef
     | UserMouseLeftTableRef
     | ClickedCell Evergreen.V6.SheetModel.CellCoords
     | PromptInputChanged String
@@ -97,7 +97,7 @@ type Msg
     | UserSqlTextChanged String
     | GotDuckDbResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbMetaResponse)
-    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbTableRefsResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbRefsResponse)
     | JumpToFirstFrame
     | JumpToFrame Int
     | JumpToLastFrame

--- a/src/Evergreen/V6/Pages/Sheet.elm
+++ b/src/Evergreen/V6/Pages/Sheet.elm
@@ -1,0 +1,107 @@
+module Evergreen.V6.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V6.Array2D
+import Evergreen.V6.DuckDb
+import Evergreen.V6.SheetModel
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type alias KeyCode =
+    String
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V6.SheetModel.RawPromptString, ( Evergreen.V6.Array2D.RowIx, Evergreen.V6.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V6.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set KeyCode
+    , selectedCell : Maybe Evergreen.V6.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbTableRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown KeyCode
+    | KeyReleased KeyCode
+    | UserSelectedTableRef Evergreen.V6.DuckDb.TableName
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.TableName
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V6.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbTableRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UploadResponded (Result Http.Error ())

--- a/src/Evergreen/V6/Pages/Sheet.elm
+++ b/src/Evergreen/V6/Pages/Sheet.elm
@@ -68,8 +68,8 @@ type alias Model =
     , nowish : Maybe Time.Posix
     , viewport : Maybe Browser.Dom.Viewport
     , renderStatus : RenderStatus
-    , selectedTableRef : Maybe Evergreen.V6.DuckDb.TableName
-    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
     }
 
 
@@ -83,8 +83,8 @@ type Msg
     | GotResizeEvent Int Int
     | KeyWentDown KeyCode
     | KeyReleased KeyCode
-    | UserSelectedTableRef Evergreen.V6.DuckDb.TableName
-    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.TableName
+    | UserSelectedTableRef Evergreen.V6.DuckDb.OwningRef
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.OwningRef
     | UserMouseLeftTableRef
     | ClickedCell Evergreen.V6.SheetModel.CellCoords
     | PromptInputChanged String

--- a/src/Evergreen/V6/Pages/VegaLite.elm
+++ b/src/Evergreen/V6/Pages/VegaLite.elm
@@ -16,9 +16,9 @@ type Position
 type alias Model =
     { duckDbForPlotResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbQueryResponse
     , duckDbMetaResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbMetaResponse
-    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbTableRefsResponse
-    , selectedTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
-    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.DuckDbRef
     , data :
         { count : Int
         , position : Position
@@ -32,12 +32,12 @@ type alias Model =
 type Msg
     = FetchPlotData
     | FetchTableRefs
-    | FetchMetaDataForRef Evergreen.V6.DuckDb.OwningRef
+    | FetchMetaDataForRef Evergreen.V6.DuckDb.DuckDbRef
     | GotDuckDbResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbMetaResponse)
-    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbTableRefsResponse)
-    | UserSelectedTableRef Evergreen.V6.DuckDb.OwningRef
-    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.OwningRef
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V6.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.DuckDbRef
     | UserMouseLeftTableRef
     | UserClickKimballColumnTab Evergreen.V6.QueryBuilder.KimballColumn
     | DropDownToggled Evergreen.V6.QueryBuilder.ColumnRef

--- a/src/Evergreen/V6/Pages/VegaLite.elm
+++ b/src/Evergreen/V6/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V6.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V6.DuckDb
+import Evergreen.V6.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbTableRefsResponse
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V6.QueryBuilder.ColumnRef Evergreen.V6.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V6.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V6.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V6.DuckDb.TableName
+    | GotDuckDbResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbTableRefsResponse)
+    | UserSelectedTableRef Evergreen.V6.DuckDb.TableName
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.TableName
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V6.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V6.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V6.QueryBuilder.ColumnRef Evergreen.V6.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V6.QueryBuilder.ColumnRef Evergreen.V6.QueryBuilder.Aggregation

--- a/src/Evergreen/V6/Pages/VegaLite.elm
+++ b/src/Evergreen/V6/Pages/VegaLite.elm
@@ -17,8 +17,8 @@ type alias Model =
     { duckDbForPlotResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbQueryResponse
     , duckDbMetaResponse : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbMetaResponse
     , duckDbTableRefs : RemoteData.WebData Evergreen.V6.DuckDb.DuckDbTableRefsResponse
-    , selectedTableRef : Maybe Evergreen.V6.DuckDb.TableName
-    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.TableName
+    , selectedTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
+    , hoveredOnTableRef : Maybe Evergreen.V6.DuckDb.OwningRef
     , data :
         { count : Int
         , position : Position
@@ -32,12 +32,12 @@ type alias Model =
 type Msg
     = FetchPlotData
     | FetchTableRefs
-    | FetchMetaDataForRef Evergreen.V6.DuckDb.TableName
+    | FetchMetaDataForRef Evergreen.V6.DuckDb.OwningRef
     | GotDuckDbResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbMetaResponse)
     | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V6.DuckDb.DuckDbTableRefsResponse)
-    | UserSelectedTableRef Evergreen.V6.DuckDb.TableName
-    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.TableName
+    | UserSelectedTableRef Evergreen.V6.DuckDb.OwningRef
+    | UserMouseEnteredTableRef Evergreen.V6.DuckDb.OwningRef
     | UserMouseLeftTableRef
     | UserClickKimballColumnTab Evergreen.V6.QueryBuilder.KimballColumn
     | DropDownToggled Evergreen.V6.QueryBuilder.ColumnRef

--- a/src/Evergreen/V6/QueryBuilder.elm
+++ b/src/Evergreen/V6/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V6.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V6/Shared.elm
+++ b/src/Evergreen/V6/Shared.elm
@@ -1,0 +1,12 @@
+module Evergreen.V6.Shared exposing (..)
+
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V6/SheetModel.elm
+++ b/src/Evergreen/V6/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V6.SheetModel exposing (..)
+
+import Evergreen.V6.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V6.Array2D.RowIx, Evergreen.V6.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V6.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V6/Types.elm
+++ b/src/Evergreen/V6/Types.elm
@@ -1,0 +1,50 @@
+module Evergreen.V6.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V6.Bridge
+import Evergreen.V6.Gen.Pages
+import Evergreen.V6.Shared
+import Lamdera
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V6.Shared.Model
+    , page : Evergreen.V6.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V6.Shared.Msg
+    | Page Evergreen.V6.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V6.Bridge.ToBackend
+
+
+type BackendMsg
+    = NoopBackend
+
+
+type ToFrontend
+    = NoOpToFrontend

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -17,7 +17,7 @@ import Shared
 import Task
 import Types exposing (FrontendModel, FrontendMsg(..), ToFrontend(..))
 import Url exposing (Url)
-import View
+import View exposing (View)
 
 
 type alias Model =
@@ -161,6 +161,7 @@ view model =
 elements : Model -> Element Msg
 elements model =
     let
+        pageElements : View Msg
         pageElements =
             Shared.sharedView (Request.create () model.url model.key)
                 { page =
@@ -169,15 +170,6 @@ elements model =
                 , toMsg = Shared
                 }
                 model.shared
-
-        -- TODO: This feels wrong.
-        firstElement =
-            case List.head pageElements.body of
-                Nothing ->
-                    E.none
-
-                Just e ->
-                    e
     in
     E.column
         [ width fill
@@ -187,7 +179,7 @@ elements model =
         , Border.width 1
         , Border.color Palette.lightGrey
         ]
-        [ firstElement ]
+        pageElements.body
 
 
 

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -8,7 +8,7 @@ import Array2D exposing (Array2D, ColIx, RowIx, colCount, fromListOfLists, getCo
 import Browser.Dom
 import Browser.Events as Events
 import Config exposing (apiHost)
-import DuckDb exposing (DuckDbColumn(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbTableRefsResponse, OwningRef, fetchDuckDbTableRefs, queryDuckDb, refEquals, refToString)
+import DuckDb exposing (DuckDbColumn(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbRef, DuckDbTableRefsResponse, fetchDuckDbTableRefs, queryDuckDb, refEquals, refToString)
 import Effect exposing (Effect)
 import Element as E exposing (..)
 import Element.Background as Background
@@ -97,8 +97,8 @@ type alias Model =
     , nowish : Maybe Posix
     , viewport : Maybe Browser.Dom.Viewport
     , renderStatus : RenderStatus
-    , selectedTableRef : Maybe OwningRef
-    , hoveredOnTableRef : Maybe OwningRef
+    , selectedTableRef : Maybe DuckDbRef
+    , hoveredOnTableRef : Maybe DuckDbRef
     }
 
 
@@ -137,8 +137,8 @@ type Msg
     | GotResizeEvent Int Int
     | KeyWentDown KeyCode
     | KeyReleased KeyCode
-    | UserSelectedTableRef OwningRef
-    | UserMouseEnteredTableRef OwningRef
+    | UserSelectedTableRef DuckDbRef
+    | UserMouseEnteredTableRef DuckDbRef
     | UserMouseLeftTableRef
     | ClickedCell CellCoords
     | PromptInputChanged String
@@ -215,7 +215,7 @@ cell2Str cd =
                     ( "FALSE", "Boolean" )
 
 
-buildSqlText : Maybe OwningRef -> String
+buildSqlText : Maybe DuckDbRef -> String
 buildSqlText ref =
     let
         tableRef =
@@ -1202,10 +1202,10 @@ viewCatalogPanel model =
 
                 Success refsResponse ->
                     let
-                        refsSelector : List OwningRef -> Element Msg
+                        refsSelector : List DuckDbRef -> Element Msg
                         refsSelector refs =
                             let
-                                backgroundColorFor : OwningRef -> Color
+                                backgroundColorFor : DuckDbRef -> Color
                                 backgroundColorFor ref =
                                     case model.hoveredOnTableRef of
                                         Nothing ->
@@ -1254,7 +1254,7 @@ viewCatalogPanel model =
                                             else
                                                 Palette.white
 
-                                ui : OwningRef -> Element Msg
+                                ui : DuckDbRef -> Element Msg
                                 ui ref =
                                     row
                                         [ width E.fill

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -8,7 +8,7 @@ import Array2D exposing (Array2D, ColIx, RowIx, colCount, fromListOfLists, getCo
 import Browser.Dom
 import Browser.Events as Events
 import Config exposing (apiHost)
-import DuckDb exposing (DuckDbColumn(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbRef, DuckDbTableRefsResponse, fetchDuckDbTableRefs, queryDuckDb, refEquals, refToString)
+import DuckDb exposing (DuckDbColumn(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbRef, DuckDbRefsResponse, fetchDuckDbTableRefs, queryDuckDb, refEquals, refToString)
 import Effect exposing (Effect)
 import Element as E exposing (..)
 import Element.Background as Background
@@ -91,7 +91,7 @@ type alias Model =
     , uiMode : UiMode
     , duckDbResponse : WebData DuckDbQueryResponse
     , duckDbMetaResponse : WebData DuckDbMetaResponse
-    , duckDbTableRefs : WebData DuckDbTableRefsResponse
+    , duckDbTableRefs : WebData DuckDbRefsResponse
     , userSqlText : String
     , fileUploadStatus : FileUploadStatus
     , nowish : Maybe Posix
@@ -152,7 +152,7 @@ type Msg
       -- API response stuff:
     | GotDuckDbResponse (Result Http.Error DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error DuckDbMetaResponse)
-    | GotDuckDbTableRefsResponse (Result Http.Error DuckDbTableRefsResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error DuckDbRefsResponse)
       -- Timeline stuff:
       -- TODO: Should Msg take in a `model` param?
     | JumpToFirstFrame

--- a/src/Pages/VegaLite.elm
+++ b/src/Pages/VegaLite.elm
@@ -57,7 +57,7 @@ type alias Model =
     { --spec : Maybe VL.Spec
       duckDbForPlotResponse : WebData DuckDb.DuckDbQueryResponse
     , duckDbMetaResponse : WebData DuckDb.DuckDbMetaResponse
-    , duckDbTableRefs : WebData DuckDb.DuckDbTableRefsResponse
+    , duckDbTableRefs : WebData DuckDb.DuckDbRefsResponse
     , selectedTableRef : Maybe DuckDb.DuckDbRef
     , hoveredOnTableRef : Maybe DuckDb.DuckDbRef
 
@@ -108,7 +108,7 @@ type Msg
     | FetchMetaDataForRef DuckDb.DuckDbRef
     | GotDuckDbResponse (Result Http.Error DuckDb.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error DuckDb.DuckDbMetaResponse)
-    | GotDuckDbTableRefsResponse (Result Http.Error DuckDb.DuckDbTableRefsResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error DuckDb.DuckDbRefsResponse)
     | UserSelectedTableRef DuckDb.DuckDbRef
     | UserMouseEnteredTableRef DuckDb.DuckDbRef
     | UserMouseLeftTableRef
@@ -802,7 +802,29 @@ viewColumnPickerPanel model =
                 ]
 
         Failure err ->
-            el [] (text "Error!")
+            let
+                errAttrs =
+                    el
+                        [ Background.color Palette.lightGrey
+                        , Border.width 2
+                        , Border.color Palette.darkishGrey
+                        ]
+            in
+            case err of
+                BadUrl url ->
+                    errAttrs <| text <| "Bad url: " ++ url
+
+                Timeout ->
+                    errAttrs <| text <| "Request timed out!"
+
+                BadStatus int ->
+                    errAttrs <| text <| "Http status: " ++ String.fromInt int
+
+                NetworkError ->
+                    errAttrs <| text <| "An unknown network error!"
+
+                BadBody s ->
+                    errAttrs <| text <| "Bad body: " ++ s
 
 
 viewPlotPanel : Model -> Element Msg

--- a/src/Pages/VegaLite.elm
+++ b/src/Pages/VegaLite.elm
@@ -58,8 +58,8 @@ type alias Model =
       duckDbForPlotResponse : WebData DuckDb.DuckDbQueryResponse
     , duckDbMetaResponse : WebData DuckDb.DuckDbMetaResponse
     , duckDbTableRefs : WebData DuckDb.DuckDbTableRefsResponse
-    , selectedTableRef : Maybe DuckDb.OwningRef
-    , hoveredOnTableRef : Maybe DuckDb.OwningRef
+    , selectedTableRef : Maybe DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe DuckDb.DuckDbRef
 
     --, dragDrop : DragDrop.Model Int Position
     , data : { count : Int, position : Position }
@@ -105,12 +105,12 @@ type Msg
     = FetchPlotData
       --| RenderPlot
     | FetchTableRefs
-    | FetchMetaDataForRef DuckDb.OwningRef
+    | FetchMetaDataForRef DuckDb.DuckDbRef
     | GotDuckDbResponse (Result Http.Error DuckDb.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error DuckDb.DuckDbMetaResponse)
     | GotDuckDbTableRefsResponse (Result Http.Error DuckDb.DuckDbTableRefsResponse)
-    | UserSelectedTableRef DuckDb.OwningRef
-    | UserMouseEnteredTableRef DuckDb.OwningRef
+    | UserSelectedTableRef DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef DuckDb.DuckDbRef
     | UserMouseLeftTableRef
       --| DragDropMsg (DragDrop.Msg Int Position)
     | UserClickKimballColumnTab KimballColumn
@@ -880,7 +880,7 @@ viewTableRefs model =
 
         Success refsResponse ->
             let
-                refsSelector : List DuckDb.OwningRef -> Element Msg
+                refsSelector : List DuckDb.DuckDbRef -> Element Msg
                 refsSelector refs =
                     let
                         backgroundColorFor ref =
@@ -931,7 +931,7 @@ viewTableRefs model =
                                     else
                                         Palette.white
 
-                        ui : DuckDb.OwningRef -> Element Msg
+                        ui : DuckDb.DuckDbRef -> Element Msg
                         ui ref =
                             row
                                 [ width E.fill

--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -1,6 +1,6 @@
 module QueryBuilder exposing (..)
 
-import DuckDb exposing (OwningRef, refToString)
+import DuckDb exposing (DuckDbRef, refToString)
 import Utils exposing (collapseWhitespace)
 
 
@@ -63,7 +63,7 @@ type alias SqlStr =
     String
 
 
-queryBuilder : List KimballColumn -> OwningRef -> SqlStr
+queryBuilder : List KimballColumn -> DuckDbRef -> SqlStr
 queryBuilder kCols ref =
     let
         selectFields : List ColumnRef

--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -1,5 +1,6 @@
 module QueryBuilder exposing (..)
 
+import DuckDb exposing (OwningRef, refToString)
 import Utils exposing (collapseWhitespace)
 
 
@@ -62,12 +63,8 @@ type alias SqlStr =
     String
 
 
-type alias TableRef =
-    String
-
-
-queryBuilder : List KimballColumn -> TableRef -> SqlStr
-queryBuilder kCols tRef =
+queryBuilder : List KimballColumn -> OwningRef -> SqlStr
+queryBuilder kCols ref =
     let
         selectFields : List ColumnRef
         selectFields =
@@ -169,7 +166,7 @@ queryBuilder kCols tRef =
         ("select "
             ++ String.join ", " (selectFields ++ measureAggregates)
             ++ " from "
-            ++ tRef
+            ++ refToString ref
             ++ " "
             ++ groupBys
         )

--- a/src/VegaUtils.elm
+++ b/src/VegaUtils.elm
@@ -30,7 +30,7 @@ mapColToStringCol col =
                         _ ->
                             []
             in
-            { ref = col.ref
+            { ref = col.name
             , vals = mapToStringList [] vals_
             }
 
@@ -60,7 +60,7 @@ mapColToFloatCol col =
                         _ ->
                             []
             in
-            { ref = col.ref
+            { ref = col.name
             , vals = mapToFloatList [] vals_
             }
 
@@ -90,7 +90,7 @@ mapColToIntegerCol col =
                         _ ->
                             []
             in
-            { ref = col.ref
+            { ref = col.name
             , vals = mapToIntList [] vals_
             }
 

--- a/src/VegaUtils.elm
+++ b/src/VegaUtils.elm
@@ -1,6 +1,6 @@
 module VegaUtils exposing (..)
 
-import DuckDb exposing (DuckDbColumn, Val(..))
+import DuckDb exposing (DuckDbColumn(..), Val(..))
 import Utils exposing (removeNothingsFromList)
 
 
@@ -12,89 +12,122 @@ type alias ColumnParamed val =
 
 mapColToStringCol : DuckDbColumn -> ColumnParamed String
 mapColToStringCol col =
-    case col.type_ of
-        "VARCHAR" ->
-            let
-                vals_ =
-                    removeNothingsFromList col.vals
+    let
+        mapToStringList : List String -> List Val -> List String
+        mapToStringList accum vals__ =
+            case vals__ of
+                [ Varchar_ i ] ->
+                    accum ++ [ i ]
 
-                mapToStringList : List String -> List Val -> List String
-                mapToStringList accum vals__ =
-                    case vals__ of
-                        [ Varchar_ v ] ->
-                            accum ++ [ v ]
+                (Varchar_ i) :: is ->
+                    [ i ] ++ mapToStringList accum is
 
-                        (Varchar_ v) :: vs ->
-                            [ v ] ++ mapToStringList accum vs
+                _ ->
+                    []
+    in
+    case col of
+        Persisted col_ ->
+            case col_.dataType of
+                "VARCHAR" ->
+                    { ref = col_.name
+                    , vals = mapToStringList [] (removeNothingsFromList col_.vals)
+                    }
 
-                        _ ->
-                            []
-            in
-            { ref = col.name
-            , vals = mapToStringList [] vals_
-            }
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }
 
-        _ ->
-            { ref = "ERROR - STRING MAP"
-            , vals = []
-            }
+        Computed col_ ->
+            case col_.dataType of
+                "DOUBLE" ->
+                    { ref = col_.name
+                    , vals = mapToStringList [] (removeNothingsFromList col_.vals)
+                    }
+
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }
 
 
 mapColToFloatCol : DuckDbColumn -> ColumnParamed Float
 mapColToFloatCol col =
-    case col.type_ of
-        "DOUBLE" ->
-            let
-                vals_ =
-                    removeNothingsFromList col.vals
+    let
+        mapToFloatList : List Float -> List Val -> List Float
+        mapToFloatList accum vals__ =
+            case vals__ of
+                [ Float_ i ] ->
+                    accum ++ [ i ]
 
-                mapToFloatList : List Float -> List Val -> List Float
-                mapToFloatList accum vals__ =
-                    case vals__ of
-                        [ Float_ f ] ->
-                            accum ++ [ f ]
+                (Float_ i) :: is ->
+                    [ i ] ++ mapToFloatList accum is
 
-                        (Float_ f) :: fs ->
-                            [ f ] ++ mapToFloatList accum fs
+                _ ->
+                    []
+    in
+    case col of
+        Persisted col_ ->
+            case col_.dataType of
+                "DOUBLE" ->
+                    { ref = col_.name
+                    , vals = mapToFloatList [] (removeNothingsFromList col_.vals)
+                    }
 
-                        _ ->
-                            []
-            in
-            { ref = col.name
-            , vals = mapToFloatList [] vals_
-            }
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }
 
-        _ ->
-            { ref = "ERROR - FLOAT MAP"
-            , vals = []
-            }
+        Computed col_ ->
+            case col_.dataType of
+                "DOUBLE" ->
+                    { ref = col_.name
+                    , vals = mapToFloatList [] (removeNothingsFromList col_.vals)
+                    }
+
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }
 
 
 mapColToIntegerCol : DuckDbColumn -> ColumnParamed Int
 mapColToIntegerCol col =
-    case col.type_ of
-        "INTEGER" ->
-            let
-                vals_ =
-                    removeNothingsFromList col.vals
+    let
+        mapToIntList : List Int -> List Val -> List Int
+        mapToIntList accum vals__ =
+            case vals__ of
+                [ Int_ i ] ->
+                    accum ++ [ i ]
 
-                mapToIntList : List Int -> List Val -> List Int
-                mapToIntList accum vals__ =
-                    case vals__ of
-                        [ Int_ i ] ->
-                            accum ++ [ i ]
+                (Int_ i) :: is ->
+                    [ i ] ++ mapToIntList accum is
 
-                        (Int_ i) :: is ->
-                            [ i ] ++ mapToIntList accum is
+                _ ->
+                    []
+    in
+    case col of
+        Persisted col_ ->
+            case col_.dataType of
+                "INTEGER" ->
+                    { ref = col_.name
+                    , vals = mapToIntList [] (removeNothingsFromList col_.vals)
+                    }
 
-                        _ ->
-                            []
-            in
-            { ref = col.name
-            , vals = mapToIntList [] vals_
-            }
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }
 
-        _ ->
-            { ref = "ERROR - INT MAP"
-            , vals = []
-            }
+        Computed col_ ->
+            case col_.dataType of
+                "INTEGER" ->
+                    { ref = col_.name
+                    , vals = mapToIntList [] (removeNothingsFromList col_.vals)
+                    }
+
+                _ ->
+                    { ref = "ERROR - INT MAP"
+                    , vals = []
+                    }

--- a/src/VegaUtils.elm
+++ b/src/VegaUtils.elm
@@ -1,6 +1,6 @@
 module VegaUtils exposing (..)
 
-import Api exposing (Column, Val(..))
+import DuckDb exposing (DuckDbColumn, Val(..))
 import Utils exposing (removeNothingsFromList)
 
 
@@ -10,7 +10,7 @@ type alias ColumnParamed val =
     }
 
 
-mapColToStringCol : Column -> ColumnParamed String
+mapColToStringCol : DuckDbColumn -> ColumnParamed String
 mapColToStringCol col =
     case col.type_ of
         "VARCHAR" ->
@@ -40,7 +40,7 @@ mapColToStringCol col =
             }
 
 
-mapColToFloatCol : Column -> ColumnParamed Float
+mapColToFloatCol : DuckDbColumn -> ColumnParamed Float
 mapColToFloatCol col =
     case col.type_ of
         "DOUBLE" ->
@@ -70,7 +70,7 @@ mapColToFloatCol col =
             }
 
 
-mapColToIntegerCol : Column -> ColumnParamed Int
+mapColToIntegerCol : DuckDbColumn -> ColumnParamed Int
 mapColToIntegerCol col =
     case col.type_ of
         "INTEGER" ->

--- a/tests/VegaUtilsTest.elm
+++ b/tests/VegaUtilsTest.elm
@@ -1,6 +1,6 @@
 module VegaUtilsTest exposing (..)
 
-import Api exposing (Column, Val(..))
+import DuckDb exposing (DuckDbColumn, Val(..))
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Test exposing (..)
@@ -30,7 +30,7 @@ suite =
         ]
 
 
-stringColumn : Column
+stringColumn : DuckDbColumn
 stringColumn =
     { ref = "a string column"
     , type_ = "VARCHAR"
@@ -49,7 +49,7 @@ colParamedString =
     }
 
 
-integerColumn : Column
+integerColumn : DuckDbColumn
 integerColumn =
     { ref = "an int column"
     , type_ = "INTEGER"
@@ -68,7 +68,7 @@ colParamedInt =
     }
 
 
-floatColumn : Column
+floatColumn : DuckDbColumn
 floatColumn =
     { ref = "a float column"
     , type_ = "DOUBLE"


### PR DESCRIPTION
All DuckDB api calls and types are now in `DuckDb.elm`

Breaking changes have been made to JSON decoding, backend changes are required to support tables with schemas.