### PR TITLE
add elm-spa page /kimball

### DIFF
--- a/.elm-spa/generated/Gen/Model.elm
+++ b/.elm-spa/generated/Gen/Model.elm
@@ -1,10 +1,12 @@
 module Gen.Model exposing (Model(..))
 
 import Gen.Params.Home_
+import Gen.Params.Kimball
 import Gen.Params.Sheet
 import Gen.Params.VegaLite
 import Gen.Params.NotFound
 import Pages.Home_
+import Pages.Kimball
 import Pages.Sheet
 import Pages.VegaLite
 import Pages.NotFound
@@ -13,6 +15,7 @@ import Pages.NotFound
 type Model
     = Redirecting_
     | Home_ Gen.Params.Home_.Params
+    | Kimball Gen.Params.Kimball.Params Pages.Kimball.Model
     | Sheet Gen.Params.Sheet.Params Pages.Sheet.Model
     | VegaLite Gen.Params.VegaLite.Params Pages.VegaLite.Model
     | NotFound Gen.Params.NotFound.Params

--- a/.elm-spa/generated/Gen/Msg.elm
+++ b/.elm-spa/generated/Gen/Msg.elm
@@ -1,16 +1,19 @@
 module Gen.Msg exposing (Msg(..))
 
 import Gen.Params.Home_
+import Gen.Params.Kimball
 import Gen.Params.Sheet
 import Gen.Params.VegaLite
 import Gen.Params.NotFound
 import Pages.Home_
+import Pages.Kimball
 import Pages.Sheet
 import Pages.VegaLite
 import Pages.NotFound
 
 
 type Msg
-    = Sheet Pages.Sheet.Msg
+    = Kimball Pages.Kimball.Msg
+    | Sheet Pages.Sheet.Msg
     | VegaLite Pages.VegaLite.Msg
 

--- a/.elm-spa/generated/Gen/Pages.elm
+++ b/.elm-spa/generated/Gen/Pages.elm
@@ -4,6 +4,7 @@ import Browser.Navigation exposing (Key)
 import Effect exposing (Effect)
 import ElmSpa.Page
 import Gen.Params.Home_
+import Gen.Params.Kimball
 import Gen.Params.Sheet
 import Gen.Params.VegaLite
 import Gen.Params.NotFound
@@ -12,6 +13,7 @@ import Gen.Msg as Msg
 import Gen.Route as Route exposing (Route)
 import Page exposing (Page)
 import Pages.Home_
+import Pages.Kimball
 import Pages.Sheet
 import Pages.VegaLite
 import Pages.NotFound
@@ -36,6 +38,9 @@ init route =
         Route.Home_ ->
             pages.home_.init ()
     
+        Route.Kimball ->
+            pages.kimball.init ()
+    
         Route.Sheet ->
             pages.sheet.init ()
     
@@ -49,6 +54,9 @@ init route =
 update : Msg -> Model -> Shared.Model -> Url -> Key -> ( Model, Effect Msg )
 update msg_ model_ =
     case ( msg_, model_ ) of
+        ( Msg.Kimball msg, Model.Kimball params model ) ->
+            pages.kimball.update params msg model
+    
         ( Msg.Sheet msg, Model.Sheet params model ) ->
             pages.sheet.update params msg model
     
@@ -67,6 +75,9 @@ view model_ =
     
         Model.Home_ params ->
             pages.home_.view params ()
+    
+        Model.Kimball params model ->
+            pages.kimball.view params model
     
         Model.Sheet params model ->
             pages.sheet.view params model
@@ -87,6 +98,9 @@ subscriptions model_ =
         Model.Home_ params ->
             pages.home_.subscriptions params ()
     
+        Model.Kimball params model ->
+            pages.kimball.subscriptions params model
+    
         Model.Sheet params model ->
             pages.sheet.subscriptions params model
     
@@ -103,12 +117,14 @@ subscriptions model_ =
 
 pages :
     { home_ : Static Gen.Params.Home_.Params
+    , kimball : Bundle Gen.Params.Kimball.Params Pages.Kimball.Model Pages.Kimball.Msg
     , sheet : Bundle Gen.Params.Sheet.Params Pages.Sheet.Model Pages.Sheet.Msg
     , vegaLite : Bundle Gen.Params.VegaLite.Params Pages.VegaLite.Model Pages.VegaLite.Msg
     , notFound : Static Gen.Params.NotFound.Params
     }
 pages =
     { home_ = static Pages.Home_.view Model.Home_
+    , kimball = bundle Pages.Kimball.page Model.Kimball Msg.Kimball
     , sheet = bundle Pages.Sheet.page Model.Sheet Msg.Sheet
     , vegaLite = bundle Pages.VegaLite.page Model.VegaLite Msg.VegaLite
     , notFound = static Pages.NotFound.view Model.NotFound

--- a/.elm-spa/generated/Gen/Params/Kimball.elm
+++ b/.elm-spa/generated/Gen/Params/Kimball.elm
@@ -1,0 +1,12 @@
+module Gen.Params.Kimball exposing (Params, parser)
+
+import Url.Parser as Parser exposing ((</>), Parser)
+
+
+type alias Params =
+    ()
+
+
+parser =
+    (Parser.s "kimball")
+

--- a/.elm-spa/generated/Gen/Route.elm
+++ b/.elm-spa/generated/Gen/Route.elm
@@ -5,6 +5,7 @@ module Gen.Route exposing
     )
 
 import Gen.Params.Home_
+import Gen.Params.Kimball
 import Gen.Params.Sheet
 import Gen.Params.VegaLite
 import Gen.Params.NotFound
@@ -14,6 +15,7 @@ import Url.Parser as Parser exposing ((</>), Parser)
 
 type Route
     = Home_
+    | Kimball
     | Sheet
     | VegaLite
     | NotFound
@@ -27,6 +29,7 @@ fromUrl =
 routes : List (Parser (Route -> a) a)
 routes =
     [ Parser.map Home_ Gen.Params.Home_.parser
+    , Parser.map Kimball Gen.Params.Kimball.parser
     , Parser.map Sheet Gen.Params.Sheet.parser
     , Parser.map VegaLite Gen.Params.VegaLite.parser
     , Parser.map NotFound Gen.Params.NotFound.parser
@@ -43,6 +46,9 @@ toHref route =
     case route of
         Home_ ->
             joinAsHref []
+    
+        Kimball ->
+            joinAsHref [ "kimball" ]
     
         Sheet ->
             joinAsHref [ "sheet" ]

--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "avh4/elm-color": "1.0.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/file": "1.0.5",
@@ -18,6 +19,7 @@
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/list-extra": "8.6.0",
+            "elm-community/typed-svg": "7.0.0",
             "jweir/elm-iso8601": "7.0.1",
             "krisajenkins/remotedata": "6.0.1",
             "lamdera/codecs": "1.0.0",

--- a/src/DuckDb.elm
+++ b/src/DuckDb.elm
@@ -1,4 +1,4 @@
-module DuckDb exposing (ColumnName, ComputedDuckDbColumn, ComputedDuckDbColumnDescription, DuckDbColumn(..), DuckDbColumnDescription(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbRef, DuckDbRef_, DuckDbRefsResponse, PersistedDuckDbColumn, PersistedDuckDbColumnDescription, Ref, SchemaName, TableName, Val(..), fetchDuckDbTableRefs, queryDuckDb, queryDuckDbMeta, refEquals, refToString, uploadFile)
+module DuckDb exposing (ColumnName, ComputedDuckDbColumn, ComputedDuckDbColumnDescription, DuckDbColumn(..), DuckDbColumnDescription(..), DuckDbMetaResponse, DuckDbQueryResponse, DuckDbRef, DuckDbRef_(..), DuckDbRefsResponse, PersistedDuckDbColumn, PersistedDuckDbColumnDescription, Ref, SchemaName, TableName, Val(..), fetchDuckDbTableRefs, queryDuckDb, queryDuckDbMeta, refEquals, refToString, uploadFile)
 
 import Config exposing (apiHost)
 import File exposing (File)

--- a/src/Evergreen/Migrate/V8.elm
+++ b/src/Evergreen/Migrate/V8.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V8 exposing (..)
+
+import Evergreen.V7.Types as Old
+import Evergreen.V8.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgUnchanged
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgUnchanged

--- a/src/Evergreen/V8/Array2D.elm
+++ b/src/Evergreen/V8/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V8.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V8/Bridge.elm
+++ b/src/Evergreen/V8/Bridge.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Bridge exposing (..)
+
+
+type ToBackend
+    = NoopToBackend

--- a/src/Evergreen/V8/DuckDb.elm
+++ b/src/Evergreen/V8/DuckDb.elm
@@ -1,0 +1,88 @@
+module Evergreen.V8.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias DuckDbRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
+    }
+
+
+type DuckDbRef_
+    = View DuckDbRef
+    | Table DuckDbRef
+
+
+type alias ColumnName =
+    String
+
+
+type alias PersistedDuckDbColumnDescription =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias PersistedDuckDbColumn =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    }

--- a/src/Evergreen/V8/Gen/Model.elm
+++ b/src/Evergreen/V8/Gen/Model.elm
@@ -1,0 +1,19 @@
+module Evergreen.V8.Gen.Model exposing (..)
+
+import Evergreen.V8.Gen.Params.Home_
+import Evergreen.V8.Gen.Params.Kimball
+import Evergreen.V8.Gen.Params.NotFound
+import Evergreen.V8.Gen.Params.Sheet
+import Evergreen.V8.Gen.Params.VegaLite
+import Evergreen.V8.Pages.Kimball
+import Evergreen.V8.Pages.Sheet
+import Evergreen.V8.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Home_ Evergreen.V8.Gen.Params.Home_.Params
+    | Kimball Evergreen.V8.Gen.Params.Kimball.Params Evergreen.V8.Pages.Kimball.Model
+    | Sheet Evergreen.V8.Gen.Params.Sheet.Params Evergreen.V8.Pages.Sheet.Model
+    | VegaLite Evergreen.V8.Gen.Params.VegaLite.Params Evergreen.V8.Pages.VegaLite.Model
+    | NotFound Evergreen.V8.Gen.Params.NotFound.Params

--- a/src/Evergreen/V8/Gen/Msg.elm
+++ b/src/Evergreen/V8/Gen/Msg.elm
@@ -1,0 +1,11 @@
+module Evergreen.V8.Gen.Msg exposing (..)
+
+import Evergreen.V8.Pages.Kimball
+import Evergreen.V8.Pages.Sheet
+import Evergreen.V8.Pages.VegaLite
+
+
+type Msg
+    = Kimball Evergreen.V8.Pages.Kimball.Msg
+    | Sheet Evergreen.V8.Pages.Sheet.Msg
+    | VegaLite Evergreen.V8.Pages.VegaLite.Msg

--- a/src/Evergreen/V8/Gen/Pages.elm
+++ b/src/Evergreen/V8/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V8.Gen.Pages exposing (..)
+
+import Evergreen.V8.Gen.Model
+import Evergreen.V8.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V8.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V8.Gen.Msg.Msg

--- a/src/Evergreen/V8/Gen/Params/Home_.elm
+++ b/src/Evergreen/V8/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V8/Gen/Params/Kimball.elm
+++ b/src/Evergreen/V8/Gen/Params/Kimball.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Gen.Params.Kimball exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V8/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V8/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V8/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V8/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V8/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V8/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V8.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V8/Pages/Kimball.elm
+++ b/src/Evergreen/V8/Pages/Kimball.elm
@@ -1,0 +1,47 @@
+module Evergreen.V8.Pages.Kimball exposing (..)
+
+import Dict
+import Evergreen.V8.DuckDb
+import Http
+import RemoteData
+
+
+type Table
+    = Fact Evergreen.V8.DuckDb.DuckDbRef_ (List Evergreen.V8.DuckDb.DuckDbColumnDescription)
+    | Dim Evergreen.V8.DuckDb.DuckDbRef_ (List Evergreen.V8.DuckDb.DuckDbColumnDescription)
+
+
+type alias RefString =
+    String
+
+
+type alias PositionPx =
+    { x : Float
+    , y : Float
+    }
+
+
+type alias TableRenderInfo =
+    { pos : PositionPx
+    , ref : Evergreen.V8.DuckDb.DuckDbRef
+    }
+
+
+type alias Model =
+    { duckDbRefs : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , hoveredOnNodeTitle : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , tables : List Table
+    , tableRenderInfo : Dict.Dict RefString TableRenderInfo
+    }
+
+
+type Msg
+    = FetchTableRefs
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserMouseEnteredNodeTitleBar Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseLeftNodeTitleBar

--- a/src/Evergreen/V8/Pages/Sheet.elm
+++ b/src/Evergreen/V8/Pages/Sheet.elm
@@ -1,0 +1,113 @@
+module Evergreen.V8.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V8.Array2D
+import Evergreen.V8.DuckDb
+import Evergreen.V8.SheetModel
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type alias KeyCode =
+    String
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V8.SheetModel.RawPromptString, ( Evergreen.V8.Array2D.RowIx, Evergreen.V8.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V8.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set KeyCode
+    , selectedCell : Maybe Evergreen.V8.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , file : Maybe File.File
+    , proposedCsvTargetSchemaName : String
+    , proposedCsvTargetTableName : String
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown KeyCode
+    | KeyReleased KeyCode
+    | UserSelectedTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V8.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UserConfirmsUpload
+    | FileUpload_UploadResponded (Result Http.Error ())
+    | FileUpload_UserChangedSchemaName String
+    | FileUpload_UserChangedTableName String

--- a/src/Evergreen/V8/Pages/VegaLite.elm
+++ b/src/Evergreen/V8/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V8.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V8.DuckDb
+import Evergreen.V8.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V8.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V8.DuckDb.DuckDbRef
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V8.QueryBuilder.ColumnRef Evergreen.V8.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V8.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V8.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V8.DuckDb.DuckDbRef
+    | GotDuckDbResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V8.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V8.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V8.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V8.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V8.QueryBuilder.ColumnRef Evergreen.V8.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V8.QueryBuilder.ColumnRef Evergreen.V8.QueryBuilder.Aggregation

--- a/src/Evergreen/V8/QueryBuilder.elm
+++ b/src/Evergreen/V8/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V8.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V8/Shared.elm
+++ b/src/Evergreen/V8/Shared.elm
@@ -1,0 +1,12 @@
+module Evergreen.V8.Shared exposing (..)
+
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V8/SheetModel.elm
+++ b/src/Evergreen/V8/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V8.SheetModel exposing (..)
+
+import Evergreen.V8.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V8.Array2D.RowIx, Evergreen.V8.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V8.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V8/Types.elm
+++ b/src/Evergreen/V8/Types.elm
@@ -1,0 +1,50 @@
+module Evergreen.V8.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V8.Bridge
+import Evergreen.V8.Gen.Pages
+import Evergreen.V8.Shared
+import Lamdera
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V8.Shared.Model
+    , page : Evergreen.V8.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V8.Shared.Msg
+    | Page Evergreen.V8.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V8.Bridge.ToBackend
+
+
+type BackendMsg
+    = NoopBackend
+
+
+type ToFrontend
+    = NoOpToFrontend

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -1,12 +1,26 @@
 module Pages.Kimball exposing (Model, Msg, page)
 
+import DuckDb exposing (ColumnName, DuckDbColumn, DuckDbColumnDescription(..), DuckDbRef_(..), fetchDuckDbTableRefs, refToString)
 import Effect exposing (Effect)
+import Element as E exposing (..)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Events as Events
+import Element.Font as Font
+import Element.Input as Input
 import Gen.Params.Kimball exposing (Params)
+import Http
 import Page
+import Palette
+import QueryBuilder exposing (Aggregation(..), ColumnRef, Granularity(..), TimeClass(..))
+import RemoteData exposing (RemoteData(..), WebData)
 import Request
 import Shared
+import TypedSvg as S
+import TypedSvg.Attributes as SA
+import TypedSvg.Core as SC exposing (Svg)
+import TypedSvg.Types as ST
 import View exposing (View)
-import Page
 
 
 page : Shared.Model -> Request.With Params -> Page.With Model Msg
@@ -19,32 +33,124 @@ page shared req =
         }
 
 
+type
+    KimballColumn
+    -- DEPRECATED: To preserve functionality pre-/kimball assignment page I'm keeping this around, but should not be
+    --             used
+    -- TODO: Move old functionality to new
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef
+
+
 
 -- INIT
 
 
 type alias Model =
-    {}
+    { duckDbRefs : WebData DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe DuckDb.DuckDbRef
+    , tables : List Table
+    , pos : PositionPx
+    , message : String
+    }
+
+
+demoFact : Table
+demoFact =
+    Fact (DuckDb.Table { schemaName = "dwtk_demo", tableName = "fact1" })
+        [ Persisted_
+            { name = "col_1"
+            , parentRef = Table { schemaName = "dwtk_demo", tableName = "fact1" }
+            , dataType = "VARCHAR"
+            }
+        , Persisted_
+            { name = "col_2"
+            , parentRef = Table { schemaName = "dwtk_demo", tableName = "fact1" }
+            , dataType = "VARCHAR"
+            }
+        , Computed_
+            { name = "col_3__agg"
+
+            --, parentRef = Table { schemaName = "dwtk_demo", tableName = "fact1" }
+            , dataType = "FLOAT"
+            }
+        ]
+
+
+demoDim1 : Table
+demoDim1 =
+    Dim (DuckDb.Table { schemaName = "dwtk_demo", tableName = "dim1" })
+        [ Persisted_
+            { name = "col_a"
+            , parentRef = Table { schemaName = "dwtk_demo", tableName = "dim1" }
+            , dataType = "VARCHAR"
+            }
+        , Persisted_
+            { name = "col_b"
+            , parentRef = Table { schemaName = "dwtk_demo", tableName = "dim1" }
+            , dataType = "VARCHAR"
+            }
+        ]
 
 
 init : ( Model, Effect Msg )
 init =
-    ( {}, Effect.none )
+    ( { duckDbRefs = Loading -- Must also fetch table refs below
+      , selectedTableRef = Nothing
+      , hoveredOnTableRef = Nothing
+      , tables = [ demoFact, demoDim1 ]
+      , pos = { ex = 400, y = 250 }
+      , message = "init message"
+      }
+    , Effect.fromCmd <| fetchDuckDbTableRefs GotDuckDbTableRefsResponse
+    )
 
 
+type DimType
+    = Causal
+    | NonCausal
 
--- UPDATE
+
+type Table
+    = Fact DuckDbRef_ (List DuckDbColumnDescription)
+    | Dim DuckDbRef_ (List DuckDbColumnDescription)
 
 
-type Msg
-    = ReplaceMe
+type
+    Msg
+    --| FetchMetaDataForRef DuckDb.DuckDbRef
+    = FetchTableRefs
+    | GotDuckDbTableRefsResponse (Result Http.Error DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
 
 
 update : Msg -> Model -> ( Model, Effect Msg )
 update msg model =
     case msg of
-        ReplaceMe ->
+        FetchTableRefs ->
+            ( { model | duckDbRefs = Loading }, Effect.fromCmd <| fetchDuckDbTableRefs GotDuckDbTableRefsResponse )
+
+        GotDuckDbTableRefsResponse response ->
+            case response of
+                Ok refs ->
+                    ( { model | duckDbRefs = Success refs }, Effect.none )
+
+                Err err ->
+                    ( { model | duckDbRefs = Failure err }, Effect.none )
+
+        UserSelectedTableRef ref ->
             ( model, Effect.none )
+
+        UserMouseEnteredTableRef ref ->
+            ( { model | hoveredOnTableRef = Just ref }, Effect.none )
+
+        UserMouseLeftTableRef ->
+            ( { model | hoveredOnTableRef = Nothing }, Effect.none )
 
 
 
@@ -57,9 +163,337 @@ subscriptions model =
 
 
 
--- VIEW
+-- begin region view
 
 
 view : Model -> View Msg
 view model =
-    View.placeholder "Kimball"
+    let
+        title =
+            "Kimball Assignments"
+    in
+    { title = title
+    , body =
+        [ elements model
+        ]
+    }
+
+
+type alias PositionPx =
+    { ex : Float
+    , y : Float
+    }
+
+
+viewDataSourceNode : Table -> PositionPx -> Svg Msg
+viewDataSourceNode table pos =
+    let
+        ( table_, type_, backgroundColor ) =
+            case table of
+                Fact ref t ->
+                    ( t, "Fact", Palette.lightBlue )
+
+                Dim ref t ->
+                    ( t, "Dimension", Palette.green_keylime )
+
+        isProperTable : List DuckDbColumnDescription -> Bool
+        isProperTable t =
+            True
+
+        cols : List DuckDbColumnDescription
+        cols =
+            case table of
+                Fact ref cols_ ->
+                    cols_
+
+                Dim ref cols_ ->
+                    cols_
+
+        --backgroundColor : Color.Color
+        --backgroundColor =
+        --    case isProperTable table_ of
+        --        True ->
+        --            Palette.toAvhColor Palette.lightBlue
+        --
+        --        False ->
+        --            Palette.toAvhColor Palette.red
+        title : String
+        title =
+            case List.head table_ of
+                Nothing ->
+                    "No Tables!"
+
+                Just col ->
+                    case col of
+                        Persisted_ col_ ->
+                            case col_.parentRef of
+                                Table tRef ->
+                                    refToString tRef
+
+                                DuckDb.View vRef ->
+                                    refToString vRef
+
+                        Computed_ col_ ->
+                            col_.name
+
+        viewColumn : DuckDbColumnDescription -> Element Msg
+        viewColumn col =
+            let
+                name : String
+                name =
+                    case col of
+                        Persisted_ desc ->
+                            desc.name
+
+                        Computed_ desc ->
+                            desc.name
+            in
+            el [] <| E.text name
+
+        element : Element Msg
+        element =
+            column
+                [ width fill
+                , height fill
+                , Border.color Palette.black
+                , Border.width 2
+                , padding 2
+                , Background.color backgroundColor
+                ]
+                ([ el [] <| E.text title ] ++ List.map (\col -> viewColumn col) cols)
+    in
+    S.rect
+        [ SA.x (ST.px pos.ex)
+        , SA.y (ST.px pos.y)
+        , SA.width (ST.px 250)
+        , SA.height (ST.px 350)
+        ]
+        []
+
+
+
+--SC.foreignObject
+--
+--    [ E.layoutWith { options = [ noStaticStyleSheet ] } [] element ]
+
+
+viewCanvas : Model -> Element Msg
+viewCanvas model =
+    let
+        poss : List PositionPx
+        poss =
+            [ { ex = 100, y = 100 }
+            , { ex = 400, y = 250 }
+            ]
+
+        tables : List Table
+        tables =
+            [ demoFact, demoDim1 ]
+
+        --List.map (\tbl -> tbl) model.tables
+        viewStuff : String -> Element Msg
+        viewStuff s =
+            E.text s
+    in
+    el
+        [ Border.width 1
+        , Border.color Palette.darkishGrey
+        , centerY
+        , centerX
+        , Background.color Palette.white
+        ]
+    <|
+        viewStuff model.message
+
+
+
+--E.html <|
+--    S.svg
+--        [ SA.height (ST.px 800)
+--        , SA.width (ST.px 1200)
+--        ]
+--        [ viewStuff demoDim1 model.pos ]
+--[ viewDataSourceNode demoFact { x = 100, y = 200 }
+--, viewDataSourceNode demoDim1 { x = 400, y = 300 }
+--]
+
+
+elements : Model -> Element Msg
+elements model =
+    row
+        [ width fill
+        , height fill
+        ]
+        [ column
+            [ height fill
+            , width <| fillPortion 8
+            , padding 5
+            , Background.color Palette.lightGrey
+            ]
+            [ viewCanvas model
+            ]
+        , el
+            [ height fill
+            , width <| fillPortion 2
+            , Border.width 1
+            , Border.color Palette.darkishGrey
+            , padding 5
+            ]
+            (viewTableRefs model)
+        ]
+
+
+mapToKimball : DuckDbColumnDescription -> KimballColumn
+mapToKimball r =
+    -- TODO: this function serves to be placeholder logic in lieu of persisting Kimball metadata
+    --       upon successful loading of a DuckDB Ref, columns will be mapped in a "best guess" manner
+    --       this longer term intent is for this to be a 'first pass', when persisted meta data does not exist
+    --       (which should be the case when a user is first using data!). Any user interventions should be
+    --       persisted server-side
+    let
+        mapDataType : { r | dataType : String, name : ColumnName } -> KimballColumn
+        mapDataType colDesc =
+            case colDesc.dataType of
+                "VARCHAR" ->
+                    Dimension colDesc.name
+
+                "DATE" ->
+                    Time (Discrete Day) colDesc.name
+
+                "TIMESTAMP" ->
+                    Time Continuous colDesc.name
+
+                "BOOLEAN" ->
+                    Dimension colDesc.name
+
+                "INTEGER" ->
+                    Measure Sum colDesc.name
+
+                "HUGEINT" ->
+                    Measure Sum colDesc.name
+
+                "BIGINT" ->
+                    Measure Sum colDesc.name
+
+                "DOUBLE" ->
+                    Measure Sum colDesc.name
+
+                _ ->
+                    Error colDesc.name
+    in
+    case r of
+        Persisted_ colDesc ->
+            mapDataType colDesc
+
+        Computed_ colDesc ->
+            mapDataType colDesc
+
+
+viewTableRefs : Model -> Element Msg
+viewTableRefs model =
+    case model.duckDbRefs of
+        NotAsked ->
+            text "Didn't request data yet"
+
+        Loading ->
+            text "Fetching..."
+
+        Success refsResponse ->
+            let
+                refsSelector : List DuckDb.DuckDbRef -> Element Msg
+                refsSelector refs =
+                    let
+                        backgroundColorFor ref =
+                            case model.hoveredOnTableRef of
+                                Nothing ->
+                                    Palette.white
+
+                                Just ref_ ->
+                                    if ref == ref_ then
+                                        Palette.lightGrey
+
+                                    else
+                                        Palette.white
+
+                        borderColorFor ref =
+                            case model.hoveredOnTableRef of
+                                Nothing ->
+                                    Palette.white
+
+                                Just ref_ ->
+                                    if ref == ref_ then
+                                        Palette.darkishGrey
+
+                                    else
+                                        Palette.white
+
+                        borderFor ref =
+                            case model.hoveredOnTableRef of
+                                Nothing ->
+                                    { top = 1, left = 0, right = 0, bottom = 1 }
+
+                                Just ref_ ->
+                                    if ref == ref_ then
+                                        { top = 1, left = 0, right = 0, bottom = 1 }
+
+                                    else
+                                        { top = 1, left = 0, right = 0, bottom = 1 }
+
+                        innerBlobColorFor ref =
+                            case model.hoveredOnTableRef of
+                                Nothing ->
+                                    Palette.white
+
+                                Just ref_ ->
+                                    if ref == ref_ then
+                                        Palette.black
+
+                                    else
+                                        Palette.white
+
+                        ui : DuckDb.DuckDbRef -> Element Msg
+                        ui ref =
+                            row
+                                [ width E.fill
+                                , paddingXY 0 2
+                                , spacingXY 2 0
+                                , Events.onClick <| UserSelectedTableRef ref
+                                , Events.onMouseEnter <| UserMouseEnteredTableRef ref
+                                , Events.onMouseLeave <| UserMouseLeftTableRef
+                                , Background.color (backgroundColorFor ref)
+                                , Border.widthEach (borderFor ref)
+                                , Border.color (borderColorFor ref)
+                                ]
+                                [ el
+                                    [ width <| px 5
+                                    , height <| px 5
+                                    , Border.width 1
+                                    , Background.color (innerBlobColorFor ref)
+                                    ]
+                                    E.none
+                                , text <| refToString ref
+                                ]
+                    in
+                    column
+                        [ width E.fill
+                        , height E.fill
+                        , paddingXY 5 0
+                        ]
+                    <|
+                        List.map (\ref -> ui ref) refs
+            in
+            column
+                [ width E.fill
+                , height E.fill
+                , spacing 2
+                ]
+                [ text "DuckDB Refs:"
+                , refsSelector refsResponse.refs
+                ]
+
+        Failure err ->
+            text "Error"
+
+
+
+-- end region view

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -1,0 +1,65 @@
+module Pages.Kimball exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Gen.Params.Kimball exposing (Params)
+import Page
+import Request
+import Shared
+import View exposing (View)
+import Page
+
+
+page : Shared.Model -> Request.With Params -> Page.With Model Msg
+page shared req =
+    Page.advanced
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : ( Model, Effect Msg )
+init =
+    ( {}, Effect.none )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = ReplaceMe
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        ReplaceMe ->
+            ( model, Effect.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    View.placeholder "Kimball"

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -371,9 +371,13 @@ viewDataSourceNode model table pos =
                     , Background.color titleBarBackgroundColor
                     , Events.onMouseEnter (UserMouseEnteredNodeTitleBar (refOfTable table))
                     , Events.onMouseLeave UserMouseLeftNodeTitleBar
+                    , paddingXY 0 5
                     ]
                    <|
-                    el [ centerX ] (E.text title)
+                    row [ width fill, paddingXY 5 0 ]
+                        [ el [ alignLeft ] (E.text <| type_ ++ ":")
+                        , el [ alignLeft, moveRight 10 ] (E.text title)
+                        ]
                  ]
                     ++ List.map (\col -> viewColumn col) cols
                 )

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -24,7 +24,6 @@ import Html.Attributes as HA
 import Http exposing (Error(..))
 import ISO8601 as Iso
 import Json.Decode as JD
-import Json.Encode as JE
 import List.Extra as LE
 import Page
 import Palette

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -433,6 +433,7 @@ update msg model =
                     )
 
         FileUpload_UploadResponded result ->
+            -- TODO: Failure path + UI
             -- File has uploaded, clear the File from front-end model, re-fetch refs
             ( { model | file = Nothing }, Effect.fromCmd <| fetchDuckDbTableRefs GotDuckDbTableRefsResponse )
 

--- a/src/Palette.elm
+++ b/src/Palette.elm
@@ -1,5 +1,6 @@
 module Palette exposing (..)
 
+import Color as CColor
 import Element exposing (rgb255)
 
 
@@ -58,3 +59,14 @@ green_keylime =
 
 orange_error_alert =
     rgb255 0xFC 0x8F 0x32
+
+
+toAvhColor : Element.Color -> CColor.Color
+toAvhColor color =
+    -- I typically work with Element.Color in UIs, but Svg gets along better with Avh's Color,
+    -- so to keep the palette defined in one place, transform between the two
+    let
+        rgba =
+            Element.toRgb color
+    in
+    CColor.rgba rgba.red rgba.green rgba.blue rgba.alpha

--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -23,7 +23,11 @@ type TimeClass
     | Discrete Granularity
 
 
-type KimballColumn
+type
+    KimballColumn
+    -- DEPRECATED: To preserve functionality pre-/kimball assignment page I'm keeping this around, but should not be
+    --             used
+    -- TODO: Move old functionality to new
     = Dimension ColumnRef
     | Measure Aggregation ColumnRef
     | Time TimeClass ColumnRef


### PR DESCRIPTION
Adds a new front-end route, `/kimball`, which will display the Kimball assignment UI.

This completes a POC of elm-ui holding a svg canvas which contains foreign elm-ui nodes. Works very nicely!
<img width="390" alt="screenshot 1" src="https://user-images.githubusercontent.com/993431/190869412-8af6f897-5123-4164-b36a-87f712f03cb9.png">
