### PR TITLE
layout maths

### DIFF
--- a/src/Evergreen/Migrate/V13.elm
+++ b/src/Evergreen/Migrate/V13.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V13 exposing (..)
+
+import Evergreen.V12.Types as Old
+import Evergreen.V13.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgUnchanged
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgUnchanged

--- a/src/Evergreen/V13/Array2D.elm
+++ b/src/Evergreen/V13/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V13.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V13/Bridge.elm
+++ b/src/Evergreen/V13/Bridge.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Bridge exposing (..)
+
+
+type ToBackend
+    = NoopToBackend

--- a/src/Evergreen/V13/DuckDb.elm
+++ b/src/Evergreen/V13/DuckDb.elm
@@ -1,0 +1,88 @@
+module Evergreen.V13.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias DuckDbRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
+    }
+
+
+type DuckDbRef_
+    = View DuckDbRef
+    | Table DuckDbRef
+
+
+type alias ColumnName =
+    String
+
+
+type alias PersistedDuckDbColumnDescription =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias PersistedDuckDbColumn =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    }

--- a/src/Evergreen/V13/Gen/Model.elm
+++ b/src/Evergreen/V13/Gen/Model.elm
@@ -1,0 +1,19 @@
+module Evergreen.V13.Gen.Model exposing (..)
+
+import Evergreen.V13.Gen.Params.Home_
+import Evergreen.V13.Gen.Params.Kimball
+import Evergreen.V13.Gen.Params.NotFound
+import Evergreen.V13.Gen.Params.Sheet
+import Evergreen.V13.Gen.Params.VegaLite
+import Evergreen.V13.Pages.Kimball
+import Evergreen.V13.Pages.Sheet
+import Evergreen.V13.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Home_ Evergreen.V13.Gen.Params.Home_.Params
+    | Kimball Evergreen.V13.Gen.Params.Kimball.Params Evergreen.V13.Pages.Kimball.Model
+    | Sheet Evergreen.V13.Gen.Params.Sheet.Params Evergreen.V13.Pages.Sheet.Model
+    | VegaLite Evergreen.V13.Gen.Params.VegaLite.Params Evergreen.V13.Pages.VegaLite.Model
+    | NotFound Evergreen.V13.Gen.Params.NotFound.Params

--- a/src/Evergreen/V13/Gen/Msg.elm
+++ b/src/Evergreen/V13/Gen/Msg.elm
@@ -1,0 +1,11 @@
+module Evergreen.V13.Gen.Msg exposing (..)
+
+import Evergreen.V13.Pages.Kimball
+import Evergreen.V13.Pages.Sheet
+import Evergreen.V13.Pages.VegaLite
+
+
+type Msg
+    = Kimball Evergreen.V13.Pages.Kimball.Msg
+    | Sheet Evergreen.V13.Pages.Sheet.Msg
+    | VegaLite Evergreen.V13.Pages.VegaLite.Msg

--- a/src/Evergreen/V13/Gen/Pages.elm
+++ b/src/Evergreen/V13/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V13.Gen.Pages exposing (..)
+
+import Evergreen.V13.Gen.Model
+import Evergreen.V13.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V13.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V13.Gen.Msg.Msg

--- a/src/Evergreen/V13/Gen/Params/Home_.elm
+++ b/src/Evergreen/V13/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V13/Gen/Params/Kimball.elm
+++ b/src/Evergreen/V13/Gen/Params/Kimball.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Gen.Params.Kimball exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V13/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V13/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V13/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V13/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V13/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V13/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V13.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V13/Pages/Kimball.elm
+++ b/src/Evergreen/V13/Pages/Kimball.elm
@@ -1,0 +1,90 @@
+module Evergreen.V13.Pages.Kimball exposing (..)
+
+import Browser.Dom
+import Dict
+import Evergreen.V13.DuckDb
+import Html.Events.Extra.Mouse
+import Http
+import RemoteData
+
+
+type alias LayoutInfo =
+    { mainPanelWidth : Int
+    , mainPanelHeight : Int
+    , sidePanelWidth : Int
+    , canvasElementWidth : Float
+    , canvasElementHeight : Float
+    , viewBoxXMin : Float
+    , viewBoxYMin : Float
+    , viewBoxWidth : Float
+    , viewBoxHeight : Float
+    }
+
+
+type PageRenderStatus
+    = AwaitingDomInfo
+    | Ready LayoutInfo
+
+
+type Table
+    = Fact Evergreen.V13.DuckDb.DuckDbRef_ (List Evergreen.V13.DuckDb.DuckDbColumnDescription)
+    | Dim Evergreen.V13.DuckDb.DuckDbRef_ (List Evergreen.V13.DuckDb.DuckDbColumnDescription)
+
+
+type alias RefString =
+    String
+
+
+type alias PositionPx =
+    { x : Float
+    , y : Float
+    }
+
+
+type alias TableRenderInfo =
+    { pos : PositionPx
+    , ref : Evergreen.V13.DuckDb.DuckDbRef
+    }
+
+
+type DragState
+    = Idle
+    | DragInitiated Evergreen.V13.DuckDb.DuckDbRef
+    | Dragging Evergreen.V13.DuckDb.DuckDbRef (Maybe Html.Events.Extra.Mouse.Event) Html.Events.Extra.Mouse.Event TableRenderInfo
+
+
+type alias Model =
+    { duckDbRefs : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , pageRenderStatus : PageRenderStatus
+    , hoveredOnNodeTitle : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , tables : List Table
+    , tableRenderInfo : Dict.Dict RefString TableRenderInfo
+    , dragState : DragState
+    , mouseEvent : Maybe Html.Events.Extra.Mouse.Event
+    , viewPort : Maybe Browser.Dom.Viewport
+    }
+
+
+type SvgViewBoxTransformation
+    = Zoom Float
+    | Translation Float Float
+
+
+type Msg
+    = FetchTableRefs
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserMouseEnteredNodeTitleBar Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseLeftNodeTitleBar
+    | ClearNodeHoverState
+    | SvgViewBoxTransform SvgViewBoxTransformation
+    | BeginNodeDrag Evergreen.V13.DuckDb.DuckDbRef
+    | DraggedAt Html.Events.Extra.Mouse.Event
+    | DragStoppedAt Html.Events.Extra.Mouse.Event
+    | TerminateDrags
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int

--- a/src/Evergreen/V13/Pages/Sheet.elm
+++ b/src/Evergreen/V13/Pages/Sheet.elm
@@ -1,0 +1,113 @@
+module Evergreen.V13.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V13.Array2D
+import Evergreen.V13.DuckDb
+import Evergreen.V13.SheetModel
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type alias KeyCode =
+    String
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V13.SheetModel.RawPromptString, ( Evergreen.V13.Array2D.RowIx, Evergreen.V13.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V13.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set KeyCode
+    , selectedCell : Maybe Evergreen.V13.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , file : Maybe File.File
+    , proposedCsvTargetSchemaName : String
+    , proposedCsvTargetTableName : String
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown KeyCode
+    | KeyReleased KeyCode
+    | UserSelectedTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V13.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UserConfirmsUpload
+    | FileUpload_UploadResponded (Result Http.Error ())
+    | FileUpload_UserChangedSchemaName String
+    | FileUpload_UserChangedTableName String

--- a/src/Evergreen/V13/Pages/VegaLite.elm
+++ b/src/Evergreen/V13/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V13.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V13.DuckDb
+import Evergreen.V13.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V13.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V13.DuckDb.DuckDbRef
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V13.QueryBuilder.ColumnRef Evergreen.V13.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V13.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V13.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V13.DuckDb.DuckDbRef
+    | GotDuckDbResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V13.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V13.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V13.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V13.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V13.QueryBuilder.ColumnRef Evergreen.V13.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V13.QueryBuilder.ColumnRef Evergreen.V13.QueryBuilder.Aggregation

--- a/src/Evergreen/V13/QueryBuilder.elm
+++ b/src/Evergreen/V13/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V13.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V13/Shared.elm
+++ b/src/Evergreen/V13/Shared.elm
@@ -1,0 +1,12 @@
+module Evergreen.V13.Shared exposing (..)
+
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V13/SheetModel.elm
+++ b/src/Evergreen/V13/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V13.SheetModel exposing (..)
+
+import Evergreen.V13.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V13.Array2D.RowIx, Evergreen.V13.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V13.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V13/Types.elm
+++ b/src/Evergreen/V13/Types.elm
@@ -1,0 +1,50 @@
+module Evergreen.V13.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V13.Bridge
+import Evergreen.V13.Gen.Pages
+import Evergreen.V13.Shared
+import Lamdera
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V13.Shared.Model
+    , page : Evergreen.V13.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V13.Shared.Msg
+    | Page Evergreen.V13.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V13.Bridge.ToBackend
+
+
+type BackendMsg
+    = NoopBackend
+
+
+type ToFrontend
+    = NoOpToFrontend


### PR DESCRIPTION
Since svg takes in a static viewbox, dimensions must be calculated prior to rendering. This introduces resize events, view port Task, and `PageRenderStatus`, then performs the appropriate arithmetic to 1) layout the elm-ui elements, 2) embed within that the correct svg viewbox. Arithmetic is performed once before first paint, and again on any resize, or viewbox transformation (panning and zooming, for example)