### PR TITLE
Backend dimensional model creation, refactor ToFrontend Msg

### DIFF
--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -1,9 +1,12 @@
 module Backend exposing (..)
 
 import Bridge exposing (ToBackend(..))
-import Dict
-import Lamdera exposing (ClientId, SessionId)
-import Types exposing (BackendModel, BackendMsg(..), FrontendMsg(..), ToFrontend(..))
+import Dict exposing (Dict)
+import DimensionalModel exposing (DimensionalModel, DimensionalModelRef)
+import Gen.Msg
+import Lamdera exposing (ClientId, SessionId, sendToFrontend)
+import Pages.Kimball
+import Types exposing (BackendModel, BackendMsg(..), FrontendMsg(..), Session, ToFrontend(..))
 
 
 type alias Model =
@@ -22,6 +25,7 @@ app =
 init : ( Model, Cmd BackendMsg )
 init =
     ( { sessions = Dict.empty
+      , dimensionalModels = Dict.empty
       }
     , Cmd.none
     )
@@ -37,5 +41,32 @@ update msg model =
 updateFromFrontend : SessionId -> ClientId -> ToBackend -> Model -> ( Model, Cmd BackendMsg )
 updateFromFrontend sessionId clientId msg model =
     case msg of
-        NoopToBackend ->
-            ( model, Cmd.none )
+        FetchDimensionalModelRefs ->
+            let
+                refs : List DimensionalModelRef
+                refs =
+                    Dict.keys model.dimensionalModels
+            in
+            ( model, sendToFrontend clientId (DeliverDimensionalModelRefs refs) )
+
+        CreateNewDimensionalModel ref ->
+            -- Check if we already have a model of this name
+            case Dict.member ref model.dimensionalModels of
+                -- We do, don't overwrite data!
+                True ->
+                    -- TODO: Once I have a few more cases like this I'd like to establish a pattern for Lamdera
+                    --      error handling, but this NoOp prevents data from being accidentally overwritten for now
+                    ( model, Cmd.none )
+
+                False ->
+                    -- We don't, update collection with new ref, send full key list back to client
+                    let
+                        newDimModels : Dict DimensionalModelRef String
+                        newDimModels =
+                            Dict.insert ref "" model.dimensionalModels
+
+                        newRefs : List DimensionalModelRef
+                        newRefs =
+                            Dict.keys newDimModels
+                    in
+                    ( { model | dimensionalModels = newDimModels }, sendToFrontend clientId (DeliverDimensionalModelRefs newRefs) )

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -1,11 +1,19 @@
 module Bridge exposing (..)
 
-import Lamdera
-
-
-sendToBackend =
-    Lamdera.sendToBackend
+import DimensionalModel exposing (DimensionalModelRef)
 
 
 type ToBackend
-    = NoopToBackend
+    = FetchDimensionalModelRefs
+    | CreateNewDimensionalModel DimensionalModelRef
+
+
+
+-- NB: Naming conflicts with WebData, but this is for Lamdera data
+
+
+type BackendData data
+    = NotAsked_
+    | Fetching_
+    | Success_ data
+    | Error_

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -1,0 +1,9 @@
+module DimensionalModel exposing (DimensionalModel, DimensionalModelRef)
+
+
+type alias DimensionalModelRef =
+    String
+
+
+type alias DimensionalModel =
+    String

--- a/src/Evergreen/Migrate/V15.elm
+++ b/src/Evergreen/Migrate/V15.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V15 exposing (..)
+
+import Evergreen.V13.Types as Old
+import Evergreen.V15.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgOldValueIgnored
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgOldValueIgnored

--- a/src/Evergreen/V15/Array2D.elm
+++ b/src/Evergreen/V15/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V15.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V15/Bridge.elm
+++ b/src/Evergreen/V15/Bridge.elm
@@ -1,0 +1,15 @@
+module Evergreen.V15.Bridge exposing (..)
+
+import Evergreen.V15.DimensionalModel
+
+
+type BackendData data
+    = NotAsked_
+    | Fetching_
+    | Success_ data
+    | Error_
+
+
+type ToBackend
+    = FetchDimensionalModelRefs
+    | CreateNewDimensionalModel Evergreen.V15.DimensionalModel.DimensionalModelRef

--- a/src/Evergreen/V15/DimensionalModel.elm
+++ b/src/Evergreen/V15/DimensionalModel.elm
@@ -1,0 +1,9 @@
+module Evergreen.V15.DimensionalModel exposing (..)
+
+
+type alias DimensionalModelRef =
+    String
+
+
+type alias DimensionalModel =
+    String

--- a/src/Evergreen/V15/DuckDb.elm
+++ b/src/Evergreen/V15/DuckDb.elm
@@ -1,0 +1,88 @@
+module Evergreen.V15.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias DuckDbRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
+    }
+
+
+type DuckDbRef_
+    = View DuckDbRef
+    | Table DuckDbRef
+
+
+type alias ColumnName =
+    String
+
+
+type alias PersistedDuckDbColumnDescription =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias PersistedDuckDbColumn =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    }

--- a/src/Evergreen/V15/Gen/Model.elm
+++ b/src/Evergreen/V15/Gen/Model.elm
@@ -1,0 +1,19 @@
+module Evergreen.V15.Gen.Model exposing (..)
+
+import Evergreen.V15.Gen.Params.Home_
+import Evergreen.V15.Gen.Params.Kimball
+import Evergreen.V15.Gen.Params.NotFound
+import Evergreen.V15.Gen.Params.Sheet
+import Evergreen.V15.Gen.Params.VegaLite
+import Evergreen.V15.Pages.Kimball
+import Evergreen.V15.Pages.Sheet
+import Evergreen.V15.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Home_ Evergreen.V15.Gen.Params.Home_.Params
+    | Kimball Evergreen.V15.Gen.Params.Kimball.Params Evergreen.V15.Pages.Kimball.Model
+    | Sheet Evergreen.V15.Gen.Params.Sheet.Params Evergreen.V15.Pages.Sheet.Model
+    | VegaLite Evergreen.V15.Gen.Params.VegaLite.Params Evergreen.V15.Pages.VegaLite.Model
+    | NotFound Evergreen.V15.Gen.Params.NotFound.Params

--- a/src/Evergreen/V15/Gen/Msg.elm
+++ b/src/Evergreen/V15/Gen/Msg.elm
@@ -1,0 +1,11 @@
+module Evergreen.V15.Gen.Msg exposing (..)
+
+import Evergreen.V15.Pages.Kimball
+import Evergreen.V15.Pages.Sheet
+import Evergreen.V15.Pages.VegaLite
+
+
+type Msg
+    = Kimball Evergreen.V15.Pages.Kimball.Msg
+    | Sheet Evergreen.V15.Pages.Sheet.Msg
+    | VegaLite Evergreen.V15.Pages.VegaLite.Msg

--- a/src/Evergreen/V15/Gen/Pages.elm
+++ b/src/Evergreen/V15/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V15.Gen.Pages exposing (..)
+
+import Evergreen.V15.Gen.Model
+import Evergreen.V15.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V15.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V15.Gen.Msg.Msg

--- a/src/Evergreen/V15/Gen/Params/Home_.elm
+++ b/src/Evergreen/V15/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V15.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V15/Gen/Params/Kimball.elm
+++ b/src/Evergreen/V15/Gen/Params/Kimball.elm
@@ -1,0 +1,5 @@
+module Evergreen.V15.Gen.Params.Kimball exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V15/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V15/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V15.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V15/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V15/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V15.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V15/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V15/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V15.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V15/Pages/Kimball.elm
+++ b/src/Evergreen/V15/Pages/Kimball.elm
@@ -1,0 +1,97 @@
+module Evergreen.V15.Pages.Kimball exposing (..)
+
+import Browser.Dom
+import Dict
+import Evergreen.V15.Bridge
+import Evergreen.V15.DimensionalModel
+import Evergreen.V15.DuckDb
+import Html.Events.Extra.Mouse
+import Http
+import RemoteData
+
+
+type alias LayoutInfo =
+    { mainPanelWidth : Int
+    , mainPanelHeight : Int
+    , sidePanelWidth : Int
+    , canvasElementWidth : Float
+    , canvasElementHeight : Float
+    , viewBoxXMin : Float
+    , viewBoxYMin : Float
+    , viewBoxWidth : Float
+    , viewBoxHeight : Float
+    }
+
+
+type PageRenderStatus
+    = AwaitingDomInfo
+    | Ready LayoutInfo
+
+
+type Table
+    = Fact Evergreen.V15.DuckDb.DuckDbRef_ (List Evergreen.V15.DuckDb.DuckDbColumnDescription)
+    | Dim Evergreen.V15.DuckDb.DuckDbRef_ (List Evergreen.V15.DuckDb.DuckDbColumnDescription)
+
+
+type alias RefString =
+    String
+
+
+type alias PositionPx =
+    { x : Float
+    , y : Float
+    }
+
+
+type alias TableRenderInfo =
+    { pos : PositionPx
+    , ref : Evergreen.V15.DuckDb.DuckDbRef
+    }
+
+
+type DragState
+    = Idle
+    | DragInitiated Evergreen.V15.DuckDb.DuckDbRef
+    | Dragging Evergreen.V15.DuckDb.DuckDbRef (Maybe Html.Events.Extra.Mouse.Event) Html.Events.Extra.Mouse.Event TableRenderInfo
+
+
+type alias Model =
+    { duckDbRefs : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , pageRenderStatus : PageRenderStatus
+    , hoveredOnNodeTitle : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , tables : List Table
+    , tableRenderInfo : Dict.Dict RefString TableRenderInfo
+    , dragState : DragState
+    , mouseEvent : Maybe Html.Events.Extra.Mouse.Event
+    , viewPort : Maybe Browser.Dom.Viewport
+    , dimensionalModelRefs : Evergreen.V15.Bridge.BackendData (List Evergreen.V15.DimensionalModel.DimensionalModelRef)
+    , proposedNewModelName : String
+    }
+
+
+type SvgViewBoxTransformation
+    = Zoom Float
+    | Translation Float Float
+
+
+type Msg
+    = FetchTableRefs
+    | GotDimensionalModelRefs (List Evergreen.V15.DimensionalModel.DimensionalModelRef)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserMouseEnteredNodeTitleBar Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseLeftNodeTitleBar
+    | ClearNodeHoverState
+    | SvgViewBoxTransform SvgViewBoxTransformation
+    | BeginNodeDrag Evergreen.V15.DuckDb.DuckDbRef
+    | DraggedAt Html.Events.Extra.Mouse.Event
+    | DragStoppedAt Html.Events.Extra.Mouse.Event
+    | TerminateDrags
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | UpdatedNewDimModelName String
+    | UserCreatesNewDimensionalModel Evergreen.V15.DimensionalModel.DimensionalModelRef

--- a/src/Evergreen/V15/Pages/Sheet.elm
+++ b/src/Evergreen/V15/Pages/Sheet.elm
@@ -1,0 +1,113 @@
+module Evergreen.V15.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V15.Array2D
+import Evergreen.V15.DuckDb
+import Evergreen.V15.SheetModel
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type alias KeyCode =
+    String
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V15.SheetModel.RawPromptString, ( Evergreen.V15.Array2D.RowIx, Evergreen.V15.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V15.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set KeyCode
+    , selectedCell : Maybe Evergreen.V15.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , file : Maybe File.File
+    , proposedCsvTargetSchemaName : String
+    , proposedCsvTargetTableName : String
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown KeyCode
+    | KeyReleased KeyCode
+    | UserSelectedTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V15.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UserConfirmsUpload
+    | FileUpload_UploadResponded (Result Http.Error ())
+    | FileUpload_UserChangedSchemaName String
+    | FileUpload_UserChangedTableName String

--- a/src/Evergreen/V15/Pages/VegaLite.elm
+++ b/src/Evergreen/V15/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V15.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V15.DuckDb
+import Evergreen.V15.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V15.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V15.DuckDb.DuckDbRef
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V15.QueryBuilder.ColumnRef Evergreen.V15.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V15.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V15.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V15.DuckDb.DuckDbRef
+    | GotDuckDbResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V15.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V15.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V15.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V15.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V15.QueryBuilder.ColumnRef Evergreen.V15.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V15.QueryBuilder.ColumnRef Evergreen.V15.QueryBuilder.Aggregation

--- a/src/Evergreen/V15/QueryBuilder.elm
+++ b/src/Evergreen/V15/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V15.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V15/Shared.elm
+++ b/src/Evergreen/V15/Shared.elm
@@ -1,0 +1,12 @@
+module Evergreen.V15.Shared exposing (..)
+
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V15/SheetModel.elm
+++ b/src/Evergreen/V15/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V15.SheetModel exposing (..)
+
+import Evergreen.V15.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V15.Array2D.RowIx, Evergreen.V15.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V15.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V15/Types.elm
+++ b/src/Evergreen/V15/Types.elm
@@ -1,0 +1,52 @@
+module Evergreen.V15.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V15.Bridge
+import Evergreen.V15.DimensionalModel
+import Evergreen.V15.Gen.Pages
+import Evergreen.V15.Shared
+import Lamdera
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V15.Shared.Model
+    , page : Evergreen.V15.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    , dimensionalModels : Dict.Dict Evergreen.V15.DimensionalModel.DimensionalModelRef Evergreen.V15.DimensionalModel.DimensionalModel
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V15.Shared.Msg
+    | Page Evergreen.V15.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V15.Bridge.ToBackend
+
+
+type BackendMsg
+    = NoopBackend
+
+
+type ToFrontend
+    = DeliverDimensionalModelRefs (List Evergreen.V15.DimensionalModel.DimensionalModelRef)

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -8,15 +8,18 @@ import Element as E exposing (..)
 import Element.Border as Border
 import Element.Font as Font
 import Gen.Model
+import Gen.Msg
 import Gen.Pages as Pages
 import Gen.Route as Route
 import Lamdera
+import Pages.Kimball exposing (Msg(..))
 import Palette
 import Request
 import Shared
 import Task
 import Types exposing (FrontendModel, FrontendMsg(..), ToFrontend(..))
 import Url exposing (Url)
+import Utils exposing (send)
 import View exposing (View)
 
 
@@ -136,10 +139,8 @@ update msg model =
 updateFromBackend : ToFrontend -> Model -> ( Model, Cmd FrontendMsg )
 updateFromBackend msg model =
     case msg of
-        --PageMsg pageMsg ->
-        --    update (Page pageMsg) model
-        NoOpToFrontend ->
-            ( model, Cmd.none )
+        DeliverDimensionalModelRefs refs ->
+            ( model, send <| Page (Gen.Msg.Kimball (GotDimensionalModelRefs refs)) )
 
 
 

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -1,8 +1,5 @@
 module Pages.Sheet exposing (Model, Msg, page)
 
---import File exposing (File)
---import File.Select as Select
-
 import Array as A
 import Array2D exposing (Array2D, ColIx, RowIx, colCount, fromListOfLists, getCol, rowCount, setValueAt)
 import Browser.Dom
@@ -413,7 +410,6 @@ update msg model =
             -- NB: We do not upload file yet, as user must fill out a small form, then click upload!
             ( { model | file = Just file }
             , Effect.none
-              --,
             )
 
         FileUpload_UserConfirmsUpload ->

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -4,6 +4,7 @@ import Bridge
 import Browser
 import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
+import DimensionalModel exposing (DimensionalModel, DimensionalModelRef)
 import Gen.Pages as Pages
 import Lamdera exposing (ClientId, SessionId)
 import Shared
@@ -42,6 +43,7 @@ type FrontendMsg
 
 type alias BackendModel =
     { sessions : Dict SessionId Session
+    , dimensionalModels : Dict DimensionalModelRef DimensionalModel
     }
 
 
@@ -51,14 +53,8 @@ type
     = NoopBackend
 
 
-type
-    ToFrontend
-    -- TODO: Replace me, Do I need Bridge.elm?
-    = NoOpToFrontend
-
-
-
---| PageMsg Pages.Msg
+type ToFrontend
+    = DeliverDimensionalModelRefs (List DimensionalModelRef)
 
 
 type alias ToBackend =


### PR DESCRIPTION
The PR introduces the first Lamdera-owned backend data for this project. This requires sending a ToFrontend message. The elm-spa example did this by embedding its Page Msg type in ToFrontend, which introduces the limitation that all FrontendMsg types must be Wire serializable (even if in practice they never go over the Wire).

So, I've separated out the Msg types, which creates a bit of Msg chaining requirements, but I prefer that over the above limitation. (`elm/file` was preventing compilation, and I'll run into this again with vega-lite, when I restore that functionality). This is also the pattern used here: https://github.com/MartinSStewart/meetdown/blob/master/src/Frontend.elm