### PR TITLE
populate table infos from DuckDbCache

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -10,7 +10,7 @@ type LocalDevModes
 
 
 localDevMode =
-    PointToLocalDevFastApi
+    PointToProduction
 
 
 apiHost =

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -33,7 +33,10 @@ type alias Edge =
 
 type alias DimensionalModel =
     { selectedDbRefs : List DuckDbRef
-    , tableInfos : Dict DuckDbRefString ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
+    , tableInfos :
+        Dict
+            DuckDbRefString
+            ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
     , graph : Graph DuckDbRef Edge
     , ref : DimensionalModelRef
     }

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -622,7 +622,7 @@ viewDataSourceNode model renderInfo kimballAssignment =
                 , Background.color backgroundColor
                 , Font.size 14
                 ]
-                ([ el
+                [ el
                     [ Border.widthEach { top = 0, left = 0, right = 0, bottom = 2 }
                     , Border.color Palette.black
                     , width fill
@@ -632,22 +632,30 @@ viewDataSourceNode model renderInfo kimballAssignment =
                     , Events.onMouseDown (BeginNodeDrag renderInfo.ref)
                     , paddingXY 0 5
                     ]
-                   <|
+                  <|
                     row [ width fill, paddingXY 5 0 ]
                         [ el [ alignLeft ] (E.text <| type_ ++ ":")
                         , el [ alignLeft, moveRight 10 ] (E.text title)
                         ]
-                 ]
-                    ++ List.map (\col -> viewColumn col) colDescs
-                )
+                , column
+                    [ width fill
+                    , height fill
+                    ]
+                  <|
+                    List.map (\col -> viewColumn col) colDescs
+                ]
     in
     SC.foreignObject
         [ SA.x (ST.px renderInfo.pos.x)
         , SA.y (ST.px renderInfo.pos.y)
         , SA.width (ST.px 250)
-        , SA.height (ST.px 350)
+        , SA.height (ST.px 450)
         ]
-        [ E.layoutWith { options = [ noStaticStyleSheet ] } [ Events.onMouseLeave ClearNodeHoverState ] element ]
+        [ E.layoutWith { options = [ noStaticStyleSheet ] }
+            [ Events.onMouseLeave ClearNodeHoverState
+            ]
+            element
+        ]
 
 
 viewCanvas : Model -> LayoutInfo -> Element Msg


### PR DESCRIPTION
Upon a creation of a dimensional model, all known tables are given an `Unassigned` classification, and a first rendering position the the graph view.

There are some visual issues with scroll bars when the content of the card requires more space than allotted by the `Svg.foreignObject`. I'm punting on these until I work through the graph building.