### PR TITLE
Naive column pairing for dimensional modeling assistance

### DIFF
--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -2,7 +2,7 @@ module Backend exposing (..)
 
 import Bridge exposing (BackendErrorMessage(..), DeliveryEnvelope(..), DimensionalModelUpdate(..), DuckDbCache, DuckDbCache_(..), DuckDbMetaDataCacheEntry, ToBackend(..), defaultColdCache)
 import Dict exposing (Dict)
-import DimensionalModel exposing (DimensionalModel, DimensionalModelRef, KimballAssignment(..), PositionPx, TableRenderInfo)
+import DimensionalModel exposing (CardRenderInfo, DimModelDuckDbSourceInfo, DimensionalModel, DimensionalModelRef, KimballAssignment(..), PositionPx)
 import DuckDb exposing (DuckDbColumnDescription, DuckDbRef, DuckDbRefString, DuckDbRef_(..), fetchDuckDbTableRefs, pingServer, queryDuckDbMeta, refToString)
 import Graph
 import Lamdera exposing (ClientId, SessionId, broadcast, sendToFrontend)
@@ -206,15 +206,23 @@ updateFromFrontend sessionId clientId msg model =
                     case Dict.get dimRef model.dimensionalModels of
                         Just dimModel ->
                             case Dict.get (refToString duckDbRef) dimModel.tableInfos of
-                                Just ( _, assignment ) ->
+                                Just info ->
                                     let
-                                        newTableInfos : Dict DuckDbRefString ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
-                                        newTableInfos =
-                                            Dict.insert (refToString duckDbRef) ( { pos = positionPx, ref = duckDbRef }, assignment ) dimModel.tableInfos
+                                        renderInfo : CardRenderInfo
+                                        renderInfo =
+                                            info.renderInfo
+
+                                        newRenderInfo : CardRenderInfo
+                                        newRenderInfo =
+                                            { renderInfo | pos = positionPx }
+
+                                        newInfo : DimModelDuckDbSourceInfo
+                                        newInfo =
+                                            { info | renderInfo = newRenderInfo }
 
                                         newDimModel : DimensionalModel
                                         newDimModel =
-                                            { dimModel | tableInfos = newTableInfos }
+                                            { dimModel | tableInfos = Dict.insert (refToString duckDbRef) newInfo dimModel.tableInfos }
                                     in
                                     ( { model | dimensionalModels = Dict.insert dimRef newDimModel model.dimensionalModels }
                                     , sendToFrontend clientId (BackendSuccess (DeliverDimensionalModel newDimModel))
@@ -230,15 +238,19 @@ updateFromFrontend sessionId clientId msg model =
                     case Dict.get dimRef model.dimensionalModels of
                         Just dimModel ->
                             case Dict.get (refToString duckDbRef) dimModel.tableInfos of
-                                Just ( renderInfo, _ ) ->
+                                Just info ->
                                     let
-                                        newTableInfos : Dict DuckDbRefString ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
-                                        newTableInfos =
-                                            Dict.insert (refToString duckDbRef) ( renderInfo, kimballAssignment ) dimModel.tableInfos
+                                        newInfo : DimModelDuckDbSourceInfo
+                                        newInfo =
+                                            { info | assignment = kimballAssignment }
+
+                                        newInfos : Dict DuckDbRefString DimModelDuckDbSourceInfo
+                                        newInfos =
+                                            Dict.insert (refToString duckDbRef) newInfo dimModel.tableInfos
 
                                         newDimModel : DimensionalModel
                                         newDimModel =
-                                            { dimModel | tableInfos = newTableInfos }
+                                            { dimModel | tableInfos = newInfos }
                                     in
                                     ( { model | dimensionalModels = Dict.insert dimRef newDimModel model.dimensionalModels }
                                     , sendToFrontend clientId (BackendSuccess (DeliverDimensionalModel newDimModel))
@@ -265,74 +277,34 @@ updateFromFrontend sessionId clientId msg model =
                         Nothing ->
                             ( model, sendToFrontend clientId (BackendError (PlainMessage ("model of ref '" ++ dimRef ++ "' not found"))) )
 
-        --UpdateDimensionalModel newRef oldDimModel ->
-        --    let
-        --        startingPosition : PositionPx
-        --        startingPosition =
-        --            { x = 10 * toFloat (Dict.size oldDimModel.tableInfos)
-        --            , y = 10 * toFloat (Dict.size oldDimModel.tableInfos)
-        --            }
-        --
-        --        columns : List DuckDbColumnDescription
-        --        columns =
-        --            let
-        --                lookup : DuckDbCache -> List DuckDbColumnDescription
-        --                lookup cache =
-        --                    case Dict.get (refToString newRef) cache.metaData of
-        --                        Just entry ->
-        --                            entry.columnDescriptions
-        --
-        --                        Nothing ->
-        --                            []
-        --            in
-        --            case model.duckDbCache of
-        --                Cold cache ->
-        --                    lookup cache
-        --
-        --                WarmingCycleInitiated cache ->
-        --                    lookup cache
-        --
-        --                Warming cache _ _ ->
-        --                    lookup cache
-        --
-        --                Hot cache ->
-        --                    lookup cache
-        --
-        --        startingKimballAssignment : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription)
-        --        startingKimballAssignment =
-        --            Unassigned (DuckDbTable newRef) columns
-        --
-        --        newTableInfos : Dict DuckDbRefString ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
-        --        newTableInfos =
-        --            let
-        --                info : TableRenderInfo
-        --                info =
-        --                    { ref = newRef
-        --                    , pos = startingPosition
-        --                    }
-        --            in
-        --            Dict.insert (refToString newRef) ( info, startingKimballAssignment ) oldDimModel.tableInfos
-        --
-        --        newDimModel : DimensionalModel
-        --        newDimModel =
-        --            { oldDimModel | tableInfos = newTableInfos }
-        --    in
-        --    case Dict.member newDimModel.ref model.dimensionalModels of
-        --        True ->
-        --            let
-        --                updatedDimModels : Dict DimensionalModelRef DimensionalModel
-        --                updatedDimModels =
-        --                    Dict.insert newDimModel.ref newDimModel model.dimensionalModels
-        --            in
-        --            -- TODO: user-scoped broadcasting, needs auth
-        --            ( { model | dimensionalModels = updatedDimModels }
-        --            , sendToFrontend clientId (DeliverDimensionalModel newDimModel)
-        --            )
-        --
-        --        False ->
-        --            -- TODO: Once I have a few more cases like this I'd like to establish a pattern for Lamdera
-        --            --      error handling, but this NoOp is safe for now
-        --            ( model, sendToFrontend clientId Noop_Error )
+                ToggleIncludedNode dimModelRef duckDbRef ->
+                    case Dict.get dimModelRef model.dimensionalModels of
+                        Just dimModel ->
+                            case Dict.get (refToString duckDbRef) dimModel.tableInfos of
+                                Just info ->
+                                    let
+                                        newInfo : DimModelDuckDbSourceInfo
+                                        newInfo =
+                                            { info | isIncluded = not info.isIncluded }
+
+                                        newInfos : Dict DuckDbRefString DimModelDuckDbSourceInfo
+                                        newInfos =
+                                            Dict.insert (refToString duckDbRef) newInfo dimModel.tableInfos
+
+                                        newDimModel : DimensionalModel
+                                        newDimModel =
+                                            { dimModel | tableInfos = newInfos }
+                                    in
+                                    ( { model | dimensionalModels = Dict.insert dimModelRef newDimModel model.dimensionalModels }
+                                    , sendToFrontend clientId (BackendSuccess (DeliverDimensionalModel newDimModel))
+                                    )
+
+                                Nothing ->
+                                    ( model, sendToFrontend clientId (BackendError (PlainMessage ("requested duckDbRef '" ++ refToString duckDbRef ++ "' not found"))) )
+
+                        Nothing ->
+                            ( model, sendToFrontend clientId (BackendError (PlainMessage ("requested dimensionalModelRef '" ++ dimModelRef ++ "' not found"))) )
+
         Admin_FetchAllBackendData ->
             let
                 sessionIds =

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -9,7 +9,6 @@ type ToBackend
     = FetchDimensionalModelRefs
     | CreateNewDimensionalModel DimensionalModelRef
     | FetchDimensionalModel DimensionalModelRef
-    | FetchDuckDbMetaData DuckDbRef
     | UpdateDimensionalModel DuckDbRef DimensionalModel
     | Admin_FetchAllBackendData
     | Admin_PingServer

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -21,6 +21,7 @@ type ToBackend
 type DimensionalModelUpdate
     = FullReplacement DimensionalModelRef DimensionalModel
     | UpdateNodePosition DimensionalModelRef DuckDbRef PositionPx
+    | AddDuckDbRefToModel DimensionalModelRef DuckDbRef
     | ToggleIncludedNode DimensionalModelRef DuckDbRef
     | UpdateAssignment DimensionalModelRef DuckDbRef (KimballAssignment DuckDbRef_ (List DuckDbColumnDescription))
     | UpdateGraph DimensionalModelRef (Graph DuckDbRef_ DimensionalModelEdge)
@@ -30,8 +31,8 @@ type DimensionalModelUpdate
 -- NB: Naming conflicts with WebData, but this is for Lamdera data
 
 
-type BackendErrorMessage
-    = PlainMessage String
+type alias BackendErrorMessage =
+    String
 
 
 type DeliveryEnvelope data

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -9,7 +9,8 @@ type ToBackend
     = FetchDimensionalModelRefs
     | CreateNewDimensionalModel DimensionalModelRef
     | FetchDimensionalModel DimensionalModelRef
-    | UpdateDimensionalModel DimensionalModel
+    | FetchDuckDbMetaData DuckDbRef
+    | UpdateDimensionalModel DuckDbRef DimensionalModel
     | Admin_FetchAllBackendData
     | Admin_PingServer
     | Admin_InitiateDuckDbCacheWarmingCycle

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -21,6 +21,7 @@ type ToBackend
 type DimensionalModelUpdate
     = FullReplacement DimensionalModelRef DimensionalModel
     | UpdateNodePosition DimensionalModelRef DuckDbRef PositionPx
+    | ToggleIncludedNode DimensionalModelRef DuckDbRef
     | UpdateAssignment DimensionalModelRef DuckDbRef (KimballAssignment DuckDbRef_ (List DuckDbColumnDescription))
     | UpdateGraph DimensionalModelRef (Graph DuckDbRef_ DimensionalModelEdge)
 

--- a/src/Bridge.elm
+++ b/src/Bridge.elm
@@ -1,20 +1,28 @@
 module Bridge exposing (..)
 
 import Dict exposing (Dict)
-import DimensionalModel exposing (DimensionalModel, DimensionalModelRef)
-import DuckDb exposing (DuckDbColumnDescription, DuckDbRef, DuckDbRefString)
+import DimensionalModel exposing (DimensionalModel, DimensionalModelEdge, DimensionalModelRef, KimballAssignment, PositionPx)
+import DuckDb exposing (DuckDbColumnDescription, DuckDbRef, DuckDbRefString, DuckDbRef_)
+import Graph exposing (Graph)
 
 
 type ToBackend
     = FetchDimensionalModelRefs
     | CreateNewDimensionalModel DimensionalModelRef
     | FetchDimensionalModel DimensionalModelRef
-    | UpdateDimensionalModel DuckDbRef DimensionalModel
+    | UpdateDimensionalModel DimensionalModelUpdate
     | Admin_FetchAllBackendData
     | Admin_PingServer
     | Admin_InitiateDuckDbCacheWarmingCycle
     | Admin_PurgeBackendData
     | Kimball_FetchDuckDbRefs
+
+
+type DimensionalModelUpdate
+    = FullReplacement DimensionalModelRef DimensionalModel
+    | UpdateNodePosition DimensionalModelRef DuckDbRef PositionPx
+    | UpdateAssignment DimensionalModelRef DuckDbRef (KimballAssignment DuckDbRef_ (List DuckDbColumnDescription))
+    | UpdateGraph DimensionalModelRef (Graph DuckDbRef_ DimensionalModelEdge)
 
 
 

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -33,13 +33,12 @@ type alias DimensionalModelEdge =
 
 
 type alias DimensionalModel =
-    { selectedDbRefs : List DuckDbRef
+    { ref : DimensionalModelRef
     , tableInfos :
         Dict
             DuckDbRefString
             ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
     , graph : Graph DuckDbRef_ DimensionalModelEdge
-    , ref : DimensionalModelRef
     }
 
 

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -1,4 +1,4 @@
-module DimensionalModel exposing (DimensionalModel, DimensionalModelEdge, DimensionalModelRef, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), TableRenderInfo, naiveColumnPairingStrategy)
+module DimensionalModel exposing (CardRenderInfo, DimModelDuckDbSourceInfo, DimensionalModel, DimensionalModelEdge, DimensionalModelRef, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), naiveColumnPairingStrategy)
 
 import Dict exposing (Dict)
 import DuckDb exposing (DuckDbColumnDescription(..), DuckDbRef, DuckDbRefString, DuckDbRef_(..), refToString)
@@ -12,7 +12,7 @@ type alias PositionPx =
     }
 
 
-type alias TableRenderInfo =
+type alias CardRenderInfo =
     { pos : PositionPx
     , ref : DuckDb.DuckDbRef
     }
@@ -34,11 +34,15 @@ type alias DimensionalModelEdge =
 
 type alias DimensionalModel =
     { ref : DimensionalModelRef
-    , tableInfos :
-        Dict
-            DuckDbRefString
-            ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) )
+    , tableInfos : Dict DuckDbRefString DimModelDuckDbSourceInfo
     , graph : Graph DuckDbRef_ DimensionalModelEdge
+    }
+
+
+type alias DimModelDuckDbSourceInfo =
+    { renderInfo : CardRenderInfo
+    , assignment : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription)
+    , isIncluded : Bool
     }
 
 
@@ -67,7 +71,7 @@ naiveColumnPairingStrategy dimModel =
                 DuckDbTable ref_ ->
                     Just ref_
 
-        helperFilterUnassigned : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterUnassigned : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
         helperFilterUnassigned ( _, assignment ) =
             case assignment of
                 Unassigned ref _ ->
@@ -79,7 +83,7 @@ naiveColumnPairingStrategy dimModel =
                 Dimension _ _ ->
                     Nothing
 
-        helperFilterFact : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterFact : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
         helperFilterFact ( _, assignment ) =
             case assignment of
                 Unassigned _ _ ->
@@ -91,7 +95,7 @@ naiveColumnPairingStrategy dimModel =
                 Dimension _ _ ->
                     Nothing
 
-        helperFilterDimension : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterDimension : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
         helperFilterDimension ( _, assignment ) =
             case assignment of
                 Unassigned _ _ ->

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -71,8 +71,8 @@ naiveColumnPairingStrategy dimModel =
                 DuckDbTable ref_ ->
                     Just ref_
 
-        helperFilterUnassigned : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
-        helperFilterUnassigned ( _, assignment ) =
+        helperFilterUnassigned : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) -> Maybe DuckDbRef
+        helperFilterUnassigned assignment =
             case assignment of
                 Unassigned ref _ ->
                     refDrillDown ref
@@ -83,8 +83,8 @@ naiveColumnPairingStrategy dimModel =
                 Dimension _ _ ->
                     Nothing
 
-        helperFilterFact : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
-        helperFilterFact ( _, assignment ) =
+        helperFilterFact : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) -> Maybe DuckDbRef
+        helperFilterFact assignment =
             case assignment of
                 Unassigned _ _ ->
                     Nothing
@@ -95,8 +95,8 @@ naiveColumnPairingStrategy dimModel =
                 Dimension _ _ ->
                     Nothing
 
-        helperFilterDimension : ( CardRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
-        helperFilterDimension ( _, assignment ) =
+        helperFilterDimension : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) -> Maybe DuckDbRef
+        helperFilterDimension assignment =
             case assignment of
                 Unassigned _ _ ->
                     Nothing
@@ -109,15 +109,15 @@ naiveColumnPairingStrategy dimModel =
 
         unassignedSources : List DuckDbRef
         unassignedSources =
-            List.filterMap helperFilterUnassigned (Dict.values dimModel.tableInfos)
+            List.filterMap helperFilterUnassigned (List.map (\info -> info.assignment) (Dict.values dimModel.tableInfos))
 
         factSources : List DuckDbRef
         factSources =
-            List.filterMap helperFilterFact (Dict.values dimModel.tableInfos)
+            List.filterMap helperFilterFact (List.map (\info -> info.assignment) (Dict.values dimModel.tableInfos))
 
         dimensionSources : List DuckDbRef
         dimensionSources =
-            List.filterMap helperFilterDimension (Dict.values dimModel.tableInfos)
+            List.filterMap helperFilterDimension (List.map (\info -> info.assignment) (Dict.values dimModel.tableInfos))
 
         columnsOfNode : Node DuckDbRef_ -> List ( NodeId, DuckDbColumnDescription )
         columnsOfNode node =
@@ -130,8 +130,8 @@ naiveColumnPairingStrategy dimModel =
                         Nothing ->
                             List.map2 (\nid col -> ( nid, col )) (List.repeat (List.length []) node.id) []
 
-                        Just ( _, assignments ) ->
-                            case assignments of
+                        Just info ->
+                            case info.assignment of
                                 Unassigned _ columns ->
                                     List.map2 (\nid col -> ( nid, col )) (List.repeat (List.length columns) node.id) columns
 

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -1,7 +1,7 @@
-module DimensionalModel exposing (DimensionalModel, DimensionalModelRef, KimballAssignment(..), PositionPx, TableRenderInfo)
+module DimensionalModel exposing (DimensionalModel, DimensionalModelRef, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), TableRenderInfo, naiveColumnPairingStrategy)
 
 import Dict exposing (Dict)
-import DuckDb exposing (DuckDbColumnDescription, DuckDbRef, DuckDbRefString, DuckDbRef_)
+import DuckDb exposing (DuckDbColumnDescription, DuckDbRef, DuckDbRefString, DuckDbRef_(..))
 import Graph exposing (Graph)
 
 
@@ -40,3 +40,96 @@ type alias DimensionalModel =
     , graph : Graph DuckDbRef Edge
     , ref : DimensionalModelRef
     }
+
+
+type Reason
+    = AllInputTablesMustBeAssigned
+    | InputMustContainAtLeastOneFactTable
+    | InputMustContainAtLeastOneDimensionTable
+
+
+type NaivePairingStrategyResult
+    = Success DimensionalModel
+    | Fail Reason
+
+
+naiveColumnPairingStrategy : DimensionalModel -> NaivePairingStrategyResult
+naiveColumnPairingStrategy dimModel =
+    let
+        refDrillDown : DuckDbRef_ -> Maybe DuckDbRef
+        refDrillDown ref =
+            case ref of
+                DuckDbView ref_ ->
+                    Just ref_
+
+                DuckDbTable ref_ ->
+                    Just ref_
+
+        helperFilterUnassigned : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterUnassigned ( _, assignment ) =
+            case assignment of
+                Unassigned ref _ ->
+                    refDrillDown ref
+
+                Fact _ _ ->
+                    Nothing
+
+                Dimension _ _ ->
+                    Nothing
+
+        helperFilterFact : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterFact ( _, assignment ) =
+            case assignment of
+                Unassigned _ _ ->
+                    Nothing
+
+                Fact ref _ ->
+                    refDrillDown ref
+
+                Dimension _ _ ->
+                    Nothing
+
+        helperFilterDimension : ( TableRenderInfo, KimballAssignment DuckDbRef_ (List DuckDbColumnDescription) ) -> Maybe DuckDbRef
+        helperFilterDimension ( _, assignment ) =
+            case assignment of
+                Unassigned _ _ ->
+                    Nothing
+
+                Fact _ _ ->
+                    Nothing
+
+                Dimension ref _ ->
+                    refDrillDown ref
+
+        unassignedTables : List DuckDbRef
+        unassignedTables =
+            List.filterMap helperFilterUnassigned (Dict.values dimModel.tableInfos)
+
+        factTables : List DuckDbRef
+        factTables =
+            List.filterMap helperFilterFact (Dict.values dimModel.tableInfos)
+
+        dimensionTables : List DuckDbRef
+        dimensionTables =
+            List.filterMap helperFilterDimension (Dict.values dimModel.tableInfos)
+
+        pairColumns : DimensionalModel -> DimensionalModel
+        pairColumns dimModel_ =
+            dimModel_
+    in
+    case List.length unassignedTables of
+        0 ->
+            case List.length factTables of
+                0 ->
+                    Fail InputMustContainAtLeastOneFactTable
+
+                _ ->
+                    case List.length dimensionTables of
+                        0 ->
+                            Fail InputMustContainAtLeastOneDimensionTable
+
+                        _ ->
+                            Success (pairColumns dimModel)
+
+        _ ->
+            Fail AllInputTablesMustBeAssigned

--- a/src/Evergreen/Migrate/V21.elm
+++ b/src/Evergreen/Migrate/V21.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V21 exposing (..)
+
+import Evergreen.V18.Types as Old
+import Evergreen.V21.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgOldValueIgnored
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgOldValueIgnored

--- a/src/Evergreen/V21/Array2D.elm
+++ b/src/Evergreen/V21/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V21.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V21/Bridge.elm
+++ b/src/Evergreen/V21/Bridge.elm
@@ -1,0 +1,62 @@
+module Evergreen.V21.Bridge exposing (..)
+
+import Dict
+import Evergreen.V21.DimensionalModel
+import Evergreen.V21.DuckDb
+import Graph
+
+
+type alias DuckDbMetaDataCacheEntry =
+    { ref : Evergreen.V21.DuckDb.DuckDbRef
+    , columnDescriptions : List Evergreen.V21.DuckDb.DuckDbColumnDescription
+    }
+
+
+type alias DuckDbCache =
+    { refs : List Evergreen.V21.DuckDb.DuckDbRef
+    , metaData : Dict.Dict Evergreen.V21.DuckDb.DuckDbRefString DuckDbMetaDataCacheEntry
+    }
+
+
+type DuckDbCache_
+    = Cold DuckDbCache
+    | WarmingCycleInitiated DuckDbCache
+    | Warming DuckDbCache DuckDbCache (List Evergreen.V21.DuckDb.DuckDbRef)
+    | Hot DuckDbCache
+
+
+type alias BackendErrorMessage =
+    String
+
+
+type BackendData data
+    = NotAsked_
+    | Fetching_
+    | Success_ data
+    | Error_ BackendErrorMessage
+
+
+type DimensionalModelUpdate
+    = FullReplacement Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DimensionalModel.DimensionalModel
+    | UpdateNodePosition Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DuckDb.DuckDbRef Evergreen.V21.DimensionalModel.PositionPx
+    | AddDuckDbRefToModel Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DuckDb.DuckDbRef
+    | ToggleIncludedNode Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DuckDb.DuckDbRef
+    | UpdateAssignment Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DuckDb.DuckDbRef (Evergreen.V21.DimensionalModel.KimballAssignment Evergreen.V21.DuckDb.DuckDbRef_ (List Evergreen.V21.DuckDb.DuckDbColumnDescription))
+    | UpdateGraph Evergreen.V21.DimensionalModel.DimensionalModelRef (Graph.Graph Evergreen.V21.DuckDb.DuckDbRef_ Evergreen.V21.DimensionalModel.DimensionalModelEdge)
+
+
+type ToBackend
+    = FetchDimensionalModelRefs
+    | CreateNewDimensionalModel Evergreen.V21.DimensionalModel.DimensionalModelRef
+    | FetchDimensionalModel Evergreen.V21.DimensionalModel.DimensionalModelRef
+    | UpdateDimensionalModel DimensionalModelUpdate
+    | Admin_FetchAllBackendData
+    | Admin_PingServer
+    | Admin_InitiateDuckDbCacheWarmingCycle
+    | Admin_PurgeBackendData
+    | Kimball_FetchDuckDbRefs
+
+
+type DeliveryEnvelope data
+    = BackendSuccess data
+    | BackendError BackendErrorMessage

--- a/src/Evergreen/V21/DimensionalModel.elm
+++ b/src/Evergreen/V21/DimensionalModel.elm
@@ -1,0 +1,45 @@
+module Evergreen.V21.DimensionalModel exposing (..)
+
+import Dict
+import Evergreen.V21.DuckDb
+import Graph
+
+
+type alias DimensionalModelRef =
+    String
+
+
+type alias PositionPx =
+    { x : Float
+    , y : Float
+    }
+
+
+type alias CardRenderInfo =
+    { pos : PositionPx
+    , ref : Evergreen.V21.DuckDb.DuckDbRef
+    }
+
+
+type KimballAssignment ref columns
+    = Unassigned ref columns
+    | Fact ref columns
+    | Dimension ref columns
+
+
+type alias DimModelDuckDbSourceInfo =
+    { renderInfo : CardRenderInfo
+    , assignment : KimballAssignment Evergreen.V21.DuckDb.DuckDbRef_ (List Evergreen.V21.DuckDb.DuckDbColumnDescription)
+    , isIncluded : Bool
+    }
+
+
+type alias DimensionalModelEdge =
+    ( Evergreen.V21.DuckDb.DuckDbColumnDescription, Evergreen.V21.DuckDb.DuckDbColumnDescription )
+
+
+type alias DimensionalModel =
+    { ref : DimensionalModelRef
+    , tableInfos : Dict.Dict Evergreen.V21.DuckDb.DuckDbRefString DimModelDuckDbSourceInfo
+    , graph : Graph.Graph Evergreen.V21.DuckDb.DuckDbRef_ DimensionalModelEdge
+    }

--- a/src/Evergreen/V21/DuckDb.elm
+++ b/src/Evergreen/V21/DuckDb.elm
@@ -1,0 +1,98 @@
+module Evergreen.V21.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias DuckDbRefString =
+    String
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias DuckDbRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type DuckDbRef_
+    = DuckDbView DuckDbRef
+    | DuckDbTable DuckDbRef
+
+
+type alias ColumnName =
+    String
+
+
+type alias PersistedDuckDbColumnDescription =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias PersistedDuckDbColumn =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    , refs : List DuckDbRef
+    }
+
+
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
+    }
+
+
+type alias PingResponse =
+    { message : String
+    }

--- a/src/Evergreen/V21/Gen/Model.elm
+++ b/src/Evergreen/V21/Gen/Model.elm
@@ -1,0 +1,22 @@
+module Evergreen.V21.Gen.Model exposing (..)
+
+import Evergreen.V21.Gen.Params.Admin
+import Evergreen.V21.Gen.Params.Home_
+import Evergreen.V21.Gen.Params.Kimball
+import Evergreen.V21.Gen.Params.NotFound
+import Evergreen.V21.Gen.Params.Sheet
+import Evergreen.V21.Gen.Params.VegaLite
+import Evergreen.V21.Pages.Admin
+import Evergreen.V21.Pages.Kimball
+import Evergreen.V21.Pages.Sheet
+import Evergreen.V21.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Admin Evergreen.V21.Gen.Params.Admin.Params Evergreen.V21.Pages.Admin.Model
+    | Home_ Evergreen.V21.Gen.Params.Home_.Params
+    | Kimball Evergreen.V21.Gen.Params.Kimball.Params Evergreen.V21.Pages.Kimball.Model
+    | Sheet Evergreen.V21.Gen.Params.Sheet.Params Evergreen.V21.Pages.Sheet.Model
+    | VegaLite Evergreen.V21.Gen.Params.VegaLite.Params Evergreen.V21.Pages.VegaLite.Model
+    | NotFound Evergreen.V21.Gen.Params.NotFound.Params

--- a/src/Evergreen/V21/Gen/Msg.elm
+++ b/src/Evergreen/V21/Gen/Msg.elm
@@ -1,0 +1,13 @@
+module Evergreen.V21.Gen.Msg exposing (..)
+
+import Evergreen.V21.Pages.Admin
+import Evergreen.V21.Pages.Kimball
+import Evergreen.V21.Pages.Sheet
+import Evergreen.V21.Pages.VegaLite
+
+
+type Msg
+    = Admin Evergreen.V21.Pages.Admin.Msg
+    | Kimball Evergreen.V21.Pages.Kimball.Msg
+    | Sheet Evergreen.V21.Pages.Sheet.Msg
+    | VegaLite Evergreen.V21.Pages.VegaLite.Msg

--- a/src/Evergreen/V21/Gen/Pages.elm
+++ b/src/Evergreen/V21/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V21.Gen.Pages exposing (..)
+
+import Evergreen.V21.Gen.Model
+import Evergreen.V21.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V21.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V21.Gen.Msg.Msg

--- a/src/Evergreen/V21/Gen/Params/Admin.elm
+++ b/src/Evergreen/V21/Gen/Params/Admin.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Admin exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Home_.elm
+++ b/src/Evergreen/V21/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Kimball.elm
+++ b/src/Evergreen/V21/Gen/Params/Kimball.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Kimball exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V21/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V21/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V21/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Pages/Admin.elm
+++ b/src/Evergreen/V21/Pages/Admin.elm
@@ -1,0 +1,34 @@
+module Evergreen.V21.Pages.Admin exposing (..)
+
+import Dict
+import Evergreen.V21.Bridge
+import Evergreen.V21.DimensionalModel
+import Lamdera
+
+
+type alias Model =
+    { backendModel :
+        Maybe
+            { sessionIds : List Lamdera.SessionId
+            , dimensionalModels : Dict.Dict Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DimensionalModel.DimensionalModel
+            , duckDbCache : Evergreen.V21.Bridge.DuckDbCache_
+            }
+    , proxiedServerStatus : Maybe String
+    , purgedDataStatus : Maybe String
+    , cacheRefreshStatus : Maybe String
+    }
+
+
+type Msg
+    = RefetchBackendData
+    | PurgeBackendData
+    | UserClickedRefreshBackendCache
+    | ProxyServerPingToBackend
+    | GotPurgeDataConfirmation String
+    | GotCacheRefreshConfirmation String
+    | GotProxiedServerPingStatus String
+    | GotBackendData
+        { sessionIds : List Lamdera.SessionId
+        , dimensionalModels : Dict.Dict Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DimensionalModel.DimensionalModel
+        , duckDbCache : Evergreen.V21.Bridge.DuckDbCache_
+        }

--- a/src/Evergreen/V21/Pages/Kimball.elm
+++ b/src/Evergreen/V21/Pages/Kimball.elm
@@ -1,0 +1,74 @@
+module Evergreen.V21.Pages.Kimball exposing (..)
+
+import Browser.Dom
+import Evergreen.V21.Bridge
+import Evergreen.V21.DimensionalModel
+import Evergreen.V21.DuckDb
+import Html.Events.Extra.Mouse
+
+
+type alias LayoutInfo =
+    { mainPanelWidth : Int
+    , mainPanelHeight : Int
+    , sidePanelWidth : Int
+    , canvasElementWidth : Float
+    , canvasElementHeight : Float
+    , viewBoxXMin : Float
+    , viewBoxYMin : Float
+    , viewBoxWidth : Float
+    , viewBoxHeight : Float
+    }
+
+
+type PageRenderStatus
+    = AwaitingDomInfo
+    | Ready LayoutInfo
+
+
+type DragState
+    = Idle
+    | DragInitiated Evergreen.V21.DuckDb.DuckDbRef
+    | Dragging Evergreen.V21.DuckDb.DuckDbRef (Maybe Html.Events.Extra.Mouse.Event) Html.Events.Extra.Mouse.Event Evergreen.V21.DimensionalModel.CardRenderInfo
+
+
+type alias Model =
+    { duckDbRefs : Evergreen.V21.Bridge.BackendData (List Evergreen.V21.DuckDb.DuckDbRef)
+    , selectedTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , pageRenderStatus : PageRenderStatus
+    , hoveredOnNodeTitle : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , dragState : DragState
+    , mouseEvent : Maybe Html.Events.Extra.Mouse.Event
+    , viewPort : Maybe Browser.Dom.Viewport
+    , dimensionalModelRefs : Evergreen.V21.Bridge.BackendData (List Evergreen.V21.DimensionalModel.DimensionalModelRef)
+    , proposedNewModelName : String
+    , selectedDimensionalModel : Maybe Evergreen.V21.DimensionalModel.DimensionalModel
+    }
+
+
+type SvgViewBoxTransformation
+    = Zoom Float
+    | Translation Float Float
+
+
+type Msg
+    = FetchTableRefs
+    | GotDimensionalModelRefs (List Evergreen.V21.DimensionalModel.DimensionalModelRef)
+    | GotDimensionalModel Evergreen.V21.DimensionalModel.DimensionalModel
+    | GotDuckDbTableRefsResponse (List Evergreen.V21.DuckDb.DuckDbRef)
+    | UserSelectedDimensionalModel Evergreen.V21.DimensionalModel.DimensionalModelRef
+    | UserClickedDuckDbRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserMouseEnteredNodeTitleBar Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseLeftNodeTitleBar
+    | ClearNodeHoverState
+    | SvgViewBoxTransform SvgViewBoxTransformation
+    | BeginNodeDrag Evergreen.V21.DuckDb.DuckDbRef
+    | DraggedAt Html.Events.Extra.Mouse.Event
+    | DragStoppedAt Html.Events.Extra.Mouse.Event
+    | TerminateDrags
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | UpdatedNewDimModelName String
+    | UserCreatesNewDimensionalModel Evergreen.V21.DimensionalModel.DimensionalModelRef

--- a/src/Evergreen/V21/Pages/Sheet.elm
+++ b/src/Evergreen/V21/Pages/Sheet.elm
@@ -1,0 +1,113 @@
+module Evergreen.V21.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V21.Array2D
+import Evergreen.V21.DuckDb
+import Evergreen.V21.SheetModel
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type alias KeyCode =
+    String
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V21.SheetModel.RawPromptString, ( Evergreen.V21.Array2D.RowIx, Evergreen.V21.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V21.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set KeyCode
+    , selectedCell : Maybe Evergreen.V21.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , file : Maybe File.File
+    , proposedCsvTargetSchemaName : String
+    , proposedCsvTargetTableName : String
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown KeyCode
+    | KeyReleased KeyCode
+    | UserSelectedTableRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V21.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UserConfirmsUpload
+    | FileUpload_UploadResponded (Result Http.Error ())
+    | FileUpload_UserChangedSchemaName String
+    | FileUpload_UserChangedTableName String

--- a/src/Evergreen/V21/Pages/VegaLite.elm
+++ b/src/Evergreen/V21/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V21.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V21.DuckDb
+import Evergreen.V21.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V21.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V21.DuckDb.DuckDbRef
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V21.QueryBuilder.ColumnRef Evergreen.V21.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V21.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V21.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V21.DuckDb.DuckDbRef
+    | GotDuckDbResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V21.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V21.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V21.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V21.QueryBuilder.ColumnRef Evergreen.V21.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V21.QueryBuilder.ColumnRef Evergreen.V21.QueryBuilder.Aggregation

--- a/src/Evergreen/V21/QueryBuilder.elm
+++ b/src/Evergreen/V21/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V21.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V21/Shared.elm
+++ b/src/Evergreen/V21/Shared.elm
@@ -1,0 +1,12 @@
+module Evergreen.V21.Shared exposing (..)
+
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V21/SheetModel.elm
+++ b/src/Evergreen/V21/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V21.SheetModel exposing (..)
+
+import Evergreen.V21.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V21.Array2D.RowIx, Evergreen.V21.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V21.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V21/Types.elm
+++ b/src/Evergreen/V21/Types.elm
@@ -1,0 +1,78 @@
+module Evergreen.V21.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V21.Bridge
+import Evergreen.V21.DimensionalModel
+import Evergreen.V21.DuckDb
+import Evergreen.V21.Gen.Pages
+import Evergreen.V21.Shared
+import Http
+import Lamdera
+import RemoteData
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V21.Shared.Model
+    , page : Evergreen.V21.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias ServerPingStatus =
+    RemoteData.WebData Evergreen.V21.DuckDb.PingResponse
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    , dimensionalModels : Dict.Dict Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DimensionalModel.DimensionalModel
+    , serverPingStatus : ServerPingStatus
+    , duckDbCache : Evergreen.V21.Bridge.DuckDbCache_
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V21.Shared.Msg
+    | Page Evergreen.V21.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V21.Bridge.ToBackend
+
+
+type BackendMsg
+    = BackendNoop
+    | PingServer
+    | GotPingResponse (Result Http.Error Evergreen.V21.DuckDb.PingResponse)
+    | Cache_BeginWarmingCycle
+    | Cache_ContinueCacheWarmingInProgress
+    | Cache_GotDuckDbRefsResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbRefsResponse)
+    | Cache_GotDuckDbMetaDataResponse (Result Http.Error Evergreen.V21.DuckDb.DuckDbMetaResponse)
+
+
+type ToFrontend
+    = DeliverDimensionalModelRefs (List Evergreen.V21.DimensionalModel.DimensionalModelRef)
+    | DeliverDimensionalModel (Evergreen.V21.Bridge.DeliveryEnvelope Evergreen.V21.DimensionalModel.DimensionalModel)
+    | DeliverDuckDbRefs (Evergreen.V21.Bridge.DeliveryEnvelope (List Evergreen.V21.DuckDb.DuckDbRef))
+    | Noop_Error
+    | Admin_DeliverAllBackendData
+        { sessionIds : List Lamdera.SessionId
+        , dimensionalModels : Dict.Dict Evergreen.V21.DimensionalModel.DimensionalModelRef Evergreen.V21.DimensionalModel.DimensionalModel
+        , duckDbCache : Evergreen.V21.Bridge.DuckDbCache_
+        }
+    | Admin_DeliverServerStatus String
+    | Admin_DeliverPurgeConfirmation String
+    | Admin_DeliverCacheRefreshConfirmation String

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -170,14 +170,6 @@ updateFromBackend msg model =
                 BackendError backendErrorMessage ->
                     ( model, Cmd.none )
 
-        DeliverDuckDbCacheEntry deliveryEnvelope ->
-            case deliveryEnvelope of
-                BackendSuccess cacheEntry ->
-                    ( model, send <| Page (Gen.Msg.Kimball (GotDuckDbCacheEntry cacheEntry)) )
-
-                BackendError backendErrorMessage ->
-                    ( model, Cmd.none )
-
 
 
 -- VIEW

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -144,8 +144,13 @@ updateFromBackend msg model =
         DeliverDimensionalModelRefs refs ->
             ( model, send <| Page (Gen.Msg.Kimball (GotDimensionalModelRefs refs)) )
 
-        DeliverDimensionalModel dimModel ->
-            ( model, send <| Page (Gen.Msg.Kimball (GotDimensionalModel dimModel)) )
+        DeliverDimensionalModel env ->
+            case env of
+                BackendSuccess dimModel ->
+                    ( model, send <| Page (Gen.Msg.Kimball (GotDimensionalModel dimModel)) )
+
+                BackendError backendErrorMessage ->
+                    ( model, Cmd.none )
 
         Noop_Error ->
             ( model, Cmd.none )

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -170,6 +170,14 @@ updateFromBackend msg model =
                 BackendError backendErrorMessage ->
                     ( model, Cmd.none )
 
+        DeliverDuckDbCacheEntry deliveryEnvelope ->
+            case deliveryEnvelope of
+                BackendSuccess cacheEntry ->
+                    ( model, send <| Page (Gen.Msg.Kimball (GotDuckDbCacheEntry cacheEntry)) )
+
+                BackendError backendErrorMessage ->
+                    ( model, Cmd.none )
+
 
 
 -- VIEW

--- a/src/Pages/Admin.elm
+++ b/src/Pages/Admin.elm
@@ -269,8 +269,7 @@ viewPanelQuadrant2_DimensionalModelAndDuckDbCache model =
             let
                 data :
                     List
-                        { numSelectedDbRefs : Int
-                        , numTableInfos : Int
+                        { numTableInfos : Int
                         , ref : DimensionalModelRef
                         }
                 data =
@@ -281,8 +280,7 @@ viewPanelQuadrant2_DimensionalModelAndDuckDbCache model =
                         Just model_ ->
                             List.map
                                 (\dimModel ->
-                                    { numSelectedDbRefs = List.length dimModel.selectedDbRefs
-                                    , numTableInfos = Dict.size dimModel.tableInfos
+                                    { numTableInfos = Dict.size dimModel.tableInfos
                                     , ref = dimModel.ref
                                     }
                                 )
@@ -314,26 +312,6 @@ viewPanelQuadrant2_DimensionalModelAndDuckDbCache model =
                                     , padding 3
                                     ]
                                     (el [ Font.size 12 ] <| E.text dimModel.ref)
-                      }
-                    , { header =
-                            el
-                                [ Border.color Palette.black
-                                , Border.widthEach { top = 1, right = 1, left = 1, bottom = 3 }
-                                , padding 3
-                                , Background.color Palette.lightGrey
-                                ]
-                            <|
-                                el [ Font.bold ] <|
-                                    E.text "num_selected_refs"
-                      , width = px 120
-                      , view =
-                            \data_ ->
-                                el
-                                    [ Border.color Palette.black
-                                    , Border.width 1
-                                    , padding 3
-                                    ]
-                                    (el [ Font.size 12 ] <| E.text (String.fromInt data_.numSelectedDbRefs))
                       }
                     , { header =
                             el

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -249,12 +249,12 @@ update msg model =
                                     ( Idle, Nothing )
 
                                 Just anchoredInfo_ ->
-                                    ( Dragging ref Nothing mouseEvent anchoredInfo_, Nothing )
+                                    ( Dragging ref Nothing mouseEvent anchoredInfo_, model.selectedDimensionalModel )
 
                         Dragging ref firstEvent oldEvent anchoredInfo ->
                             case firstEvent of
                                 Nothing ->
-                                    ( Dragging ref (Just oldEvent) mouseEvent anchoredInfo, Nothing )
+                                    ( Dragging ref (Just oldEvent) mouseEvent anchoredInfo, model.selectedDimensionalModel )
 
                                 Just firstEvent_ ->
                                     let
@@ -348,6 +348,7 @@ update msg model =
                                     in
                                     case newPos of
                                         Just newPos_ ->
+                                            --Cmd.none
                                             sendToBackend <| UpdateDimensionalModel (UpdateNodePosition dimModel.ref ref_ newPos_)
 
                                         Nothing ->
@@ -410,7 +411,6 @@ update msg model =
                             in
                             ( { model | pageRenderStatus = Ready newLayoutInfo }, Effect.none )
 
-        --( { model | svgViewBox = defaultViewBox }, Effect.none )
         ClearNodeHoverState ->
             ( { model | hoveredOnNodeTitle = Nothing }, Effect.none )
 
@@ -582,13 +582,6 @@ viewDataSourceNode model renderInfo kimballAssignment =
                 , moveRight 3
                 , paddingXY 5 2
                 , spacingXY 4 0
-
-                --, Events.onClick <| UserSelectedTableRef ref
-                --, Events.onMouseEnter <| UserMouseEnteredTableRef ref
-                --, Events.onMouseLeave <| UserMouseLeftTableRef
-                --, Background.color (backgroundColorFor ref)
-                --, Border.widthEach (borderFor ref)
-                --, Border.color (borderColorFor ref)
                 ]
                 [ el
                     [ width <| px 5
@@ -821,12 +814,14 @@ viewDebugPanel model =
                 Just dimModel ->
                     dimModel.ref
     in
-    column [ width fill, height fill, Border.width 1, Border.color Palette.darkishGrey ]
-        [ E.text <| "events: " ++ mouseEventStr
-        , E.text <| "drag state: " ++ dragStateStr
-        , E.text <| "veiwPort: " ++ viewPortStr
-        , E.text <| "dim model: " ++ selectedModelStr
-        ]
+    el [ width fill, height fill, Border.width 1, Border.color Palette.darkishGrey ]
+        (paragraph []
+            [ E.text <| "events: " ++ mouseEventStr
+            , E.text <| "drag state: " ++ dragStateStr
+            , E.text <| "veiwPort: " ++ viewPortStr
+            , E.text <| "dim model: " ++ selectedModelStr
+            ]
+        )
 
 
 viewDimensionalModelRefs : Model -> Element Msg

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -12,7 +12,6 @@ import Element as E exposing (..)
 import Request exposing (Request)
 import Task
 import Time
-import Utils exposing (fromUrl, navigate)
 import View exposing (View)
 
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -4,9 +4,10 @@ import Bridge exposing (BackendData, BackendErrorMessage, DeliveryEnvelope, Duck
 import Browser
 import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
-import DimensionalModel exposing (DimensionalModel, DimensionalModelRef)
-import DuckDb exposing (DuckDbColumnDescription, DuckDbMetaResponse, DuckDbRef, DuckDbRefString, DuckDbRefsResponse, PingResponse)
+import DimensionalModel exposing (DimensionalModel, DimensionalModelEdge, DimensionalModelRef, KimballAssignment, PositionPx)
+import DuckDb exposing (DuckDbColumnDescription, DuckDbMetaResponse, DuckDbRef, DuckDbRefString, DuckDbRef_, DuckDbRefsResponse, PingResponse)
 import Gen.Pages as Pages
+import Graph exposing (Graph)
 import Http
 import Lamdera exposing (ClientId, SessionId)
 import RemoteData exposing (WebData)
@@ -72,7 +73,6 @@ type ToFrontend
     = DeliverDimensionalModelRefs (List DimensionalModelRef)
     | DeliverDimensionalModel DimensionalModel
     | DeliverDuckDbRefs (DeliveryEnvelope (List DuckDbRef))
-    | DeliverDuckDbCacheEntry (DeliveryEnvelope DuckDbMetaDataCacheEntry)
     | Noop_Error
     | Admin_DeliverAllBackendData
         { sessionIds : List SessionId
@@ -86,3 +86,14 @@ type ToFrontend
 
 type alias ToBackend =
     Bridge.ToBackend
+
+
+
+-- TODO: Implement "dimensional model API"
+
+
+type DimensionalModelUpdate
+    = FullReplacement DimensionalModel
+    | UpdateNodePosition DuckDbRef PositionPx
+    | UpdateAssignment DuckDbRef (KimballAssignment DuckDbRef_ (List DuckDbColumnDescription))
+    | UpdateGraph (Graph DuckDbRef_ DimensionalModelEdge)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,6 +1,6 @@
 module Types exposing (..)
 
-import Bridge exposing (BackendData, BackendErrorMessage, DeliveryEnvelope, DuckDbCache_)
+import Bridge exposing (BackendData, BackendErrorMessage, DeliveryEnvelope, DuckDbCache_, DuckDbMetaDataCacheEntry)
 import Browser
 import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
@@ -72,6 +72,7 @@ type ToFrontend
     = DeliverDimensionalModelRefs (List DimensionalModelRef)
     | DeliverDimensionalModel DimensionalModel
     | DeliverDuckDbRefs (DeliveryEnvelope (List DuckDbRef))
+    | DeliverDuckDbCacheEntry (DeliveryEnvelope DuckDbMetaDataCacheEntry)
     | Noop_Error
     | Admin_DeliverAllBackendData
         { sessionIds : List SessionId

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -90,10 +90,3 @@ type alias ToBackend =
 
 
 -- TODO: Implement "dimensional model API"
-
-
-type DimensionalModelUpdate
-    = FullReplacement DimensionalModel
-    | UpdateNodePosition DuckDbRef PositionPx
-    | UpdateAssignment DuckDbRef (KimballAssignment DuckDbRef_ (List DuckDbColumnDescription))
-    | UpdateGraph (Graph DuckDbRef_ DimensionalModelEdge)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -71,7 +71,7 @@ type
 
 type ToFrontend
     = DeliverDimensionalModelRefs (List DimensionalModelRef)
-    | DeliverDimensionalModel DimensionalModel
+    | DeliverDimensionalModel (DeliveryEnvelope DimensionalModel)
     | DeliverDuckDbRefs (DeliveryEnvelope (List DuckDbRef))
     | Noop_Error
     | Admin_DeliverAllBackendData

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -1,4 +1,4 @@
-module Utils exposing (..)
+module Utils exposing (cartesian, collapseWhitespace, keyDecoder, removeNothingsFromList, send)
 
 -- miscellaneous utility functions
 
@@ -41,6 +41,13 @@ collapseWhitespace s trim =
 
                 False ->
                     Regex.replace rex (\_ -> " ") s
+
+
+cartesian : List a -> List b -> List ( a, b )
+cartesian xs ys =
+    List.concatMap
+        (\x -> List.map (\y -> ( x, y )) ys)
+        xs
 
 
 

--- a/tests/DimensionalModelTest.elm
+++ b/tests/DimensionalModelTest.elm
@@ -1,0 +1,99 @@
+module DimensionalModelTest exposing (..)
+
+import Dict
+import DimensionalModel exposing (DimensionalModel, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), naiveColumnPairingStrategy)
+import DuckDb exposing (DuckDbRef, DuckDbRef_(..), refToString)
+import Expect exposing (Expectation)
+import Graph
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "Dimensional Model Module"
+        [ describe "malformed input yields appropriate result"
+            [ test "input dimModel must have no 'Unassigned' tables"
+                (\_ -> naiveColumnPairingStrategy badModel1 |> Expect.equal (Fail AllInputTablesMustBeAssigned))
+            , test "input dimModel must have at least one 'Dimension' table"
+                (\_ -> naiveColumnPairingStrategy badModel2 |> Expect.equal (Fail InputMustContainAtLeastOneDimensionTable))
+            , test "input dimModel must have at least one 'Fact' table"
+                (\_ -> naiveColumnPairingStrategy badModel3 |> Expect.equal (Fail InputMustContainAtLeastOneFactTable))
+            , test "fail nicely if given empty input"
+                (\_ -> naiveColumnPairingStrategy emptyModel |> Expect.equal (Fail InputMustContainAtLeastOneFactTable))
+            ]
+        , describe "Good input yields graph built using naive pairing strategy"
+            [ test "happy path - case 1"
+                (\_ -> naiveColumnPairingStrategy goodModel1 |> Expect.equal (Success goodModel1))
+            ]
+        ]
+
+
+defaultPos : PositionPx
+defaultPos =
+    { x = 100, y = 100 }
+
+
+defaultRef : DuckDbRef
+defaultRef =
+    { schemaName = "test", tableName = "test_table" }
+
+
+emptyModel : DimensionalModel
+emptyModel =
+    { selectedDbRefs = []
+    , tableInfos = Dict.empty
+    , graph = Graph.empty
+    , ref = "empty_model"
+    }
+
+
+badModel1 : DimensionalModel
+badModel1 =
+    -- This model has an Unassigned table in it
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString defaultRef, ( { pos = defaultPos, ref = defaultRef }, Unassigned (DuckDbTable defaultRef) [] ) )
+            ]
+    , graph = Graph.empty
+    , ref = "bad_model_1"
+    }
+
+
+badModel2 : DimensionalModel
+badModel2 =
+    -- This model is missing a Dimension table
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString defaultRef, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
+            ]
+    , graph = Graph.empty
+    , ref = "bad_model_2"
+    }
+
+
+badModel3 : DimensionalModel
+badModel3 =
+    -- This model is missing a Fact table
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString defaultRef, ( { pos = defaultPos, ref = defaultRef }, Dimension (DuckDbTable defaultRef) [] ) )
+            ]
+    , graph = Graph.empty
+    , ref = "bad_model_3"
+    }
+
+
+goodModel1 : DimensionalModel
+goodModel1 =
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString { schemaName = "happy_path", tableName = "dim1" }, ( { pos = defaultPos, ref = defaultRef }, Dimension (DuckDbTable defaultRef) [] ) )
+            , ( refToString { schemaName = "happy_path", tableName = "fact1" }, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
+            ]
+    , graph = Graph.empty
+    , ref = "bad_model_3"
+    }

--- a/tests/DimensionalModelTest.elm
+++ b/tests/DimensionalModelTest.elm
@@ -1,10 +1,10 @@
 module DimensionalModelTest exposing (..)
 
 import Dict
-import DimensionalModel exposing (DimensionalModel, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), naiveColumnPairingStrategy)
-import DuckDb exposing (DuckDbRef, DuckDbRef_(..), refToString)
+import DimensionalModel exposing (DimensionalModel, DimensionalModelEdge, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), naiveColumnPairingStrategy)
+import DuckDb exposing (DuckDbColumnDescription(..), DuckDbRef, DuckDbRef_(..), refToString)
 import Expect exposing (Expectation)
-import Graph
+import Graph exposing (Edge, Node)
 import Test exposing (Test, describe, test)
 
 
@@ -22,8 +22,11 @@ suite =
                 (\_ -> naiveColumnPairingStrategy emptyModel |> Expect.equal (Fail InputMustContainAtLeastOneFactTable))
             ]
         , describe "Good input yields graph built using naive pairing strategy"
-            [ test "happy path - case 1"
-                (\_ -> naiveColumnPairingStrategy goodModel1 |> Expect.equal (Success goodModel1))
+            [ test "happy path - case 1. Degenerate case: tables are assigned, but there are no columns, so we do nothing"
+                (\_ -> naiveColumnPairingStrategy goodModel1 |> Expect.equal (Success goodModel1_Expected))
+
+            --, test "happy path - case 2. Single fact table with two dimensions, with two columns that should result in graph edges"
+            --    (\_ -> naiveColumnPairingStrategy goodModel2 |> Expect.equal (Success goodModel2_Expected))
             ]
         ]
 
@@ -95,5 +98,100 @@ goodModel1 =
             , ( refToString { schemaName = "happy_path", tableName = "fact1" }, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
             ]
     , graph = Graph.empty
-    , ref = "bad_model_3"
+    , ref = "good_model_1"
     }
+
+
+goodModel1_Expected : DimensionalModel
+goodModel1_Expected =
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString { schemaName = "happy_path", tableName = "dim1" }, ( { pos = defaultPos, ref = defaultRef }, Dimension (DuckDbTable defaultRef) [] ) )
+            , ( refToString { schemaName = "happy_path", tableName = "fact1" }, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
+            ]
+    , graph =
+        Graph.fromNodesAndEdges
+            [ Node 1 (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
+            , Node 2 (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
+            ]
+            []
+    , ref = "good_model_1"
+    }
+
+
+goodModel2 : DimensionalModel
+goodModel2 =
+    -- Many of the values below exist purely to make the compiler happy, but some impact the behavior we're testing
+    -- The fact table must join to each dimension table, col_b -> col_b, and col_d -> col_d
+    { selectedDbRefs = []
+    , tableInfos =
+        Dict.fromList
+            [ ( refToString { schemaName = "good_2", tableName = "fact1" }
+              , ( { pos = defaultPos, ref = defaultRef }
+                , Fact (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
+                    [ Persisted_ { name = "col_a", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+                    , Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+                    , Persisted_ { name = "col_c", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+                    , Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+                    , Persisted_ { name = "col_e", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+                    ]
+                )
+              )
+            , ( refToString { schemaName = "good_2", tableName = "dim1" }
+              , ( { pos = defaultPos, ref = defaultRef }
+                , Dimension (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
+                    [ Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+                    ]
+                )
+              )
+            , ( refToString { schemaName = "good_2", tableName = "dim2" }
+              , ( { pos = defaultPos, ref = defaultRef }
+                , Dimension (DuckDbTable { schemaName = "happy_path", tableName = "dim2" })
+                    [ Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+                    ]
+                )
+              )
+            ]
+    , graph = Graph.empty
+    , ref = "good_model_2"
+    }
+
+
+goodModel2_Expected : DimensionalModel
+goodModel2_Expected =
+    let
+        nodes : List (Node DuckDbRef_)
+        nodes =
+            [ Node 1 (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
+            , Node 2 (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
+            , Node 3 (DuckDbTable { schemaName = "happy_path", tableName = "dim2" })
+            ]
+
+        edges : List (Edge DimensionalModelEdge)
+        edges =
+            [ Edge 1
+                2
+                ( Persisted_ { name = "col_b", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" }, dataType = "VARCHAR" }
+                , Persisted_ { name = "col_b", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" }, dataType = "VARCHAR" }
+                )
+            , Edge 1
+                3
+                ( Persisted_ { name = "col_d", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" }, dataType = "VARCHAR" }
+                , Persisted_ { name = "col_d", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" }, dataType = "VARCHAR" }
+                )
+            ]
+
+        expectedGraph : Graph.Graph DuckDbRef_ DimensionalModelEdge
+        expectedGraph =
+            Graph.fromNodesAndEdges nodes edges
+    in
+    { goodModel2 | graph = expectedGraph }

--- a/tests/DimensionalModelTest.elm
+++ b/tests/DimensionalModelTest.elm
@@ -22,11 +22,10 @@ suite =
                 (\_ -> naiveColumnPairingStrategy emptyModel |> Expect.equal (Fail InputMustContainAtLeastOneFactTable))
             ]
         , describe "Good input yields graph built using naive pairing strategy"
-            [ test "happy path - case 1. Degenerate case: tables are assigned, but there are no columns, so we do nothing"
+            [ test "happy path - case 1"
                 (\_ -> naiveColumnPairingStrategy goodModel1 |> Expect.equal (Success goodModel1_Expected))
-
-            --, test "happy path - case 2. Single fact table with two dimensions, with two columns that should result in graph edges"
-            --    (\_ -> naiveColumnPairingStrategy goodModel2 |> Expect.equal (Success goodModel2_Expected))
+            , test "happy path - case 2"
+                (\_ -> naiveColumnPairingStrategy goodModel2 |> Expect.equal (Success goodModel2_Expected))
             ]
         ]
 
@@ -91,11 +90,18 @@ badModel3 =
 
 goodModel1 : DimensionalModel
 goodModel1 =
+    let
+        dim1Ref =
+            { schemaName = "good1", tableName = "dim1" }
+
+        fact1Ref =
+            { schemaName = "good1", tableName = "fact1" }
+    in
     { selectedDbRefs = []
     , tableInfos =
         Dict.fromList
-            [ ( refToString { schemaName = "happy_path", tableName = "dim1" }, ( { pos = defaultPos, ref = defaultRef }, Dimension (DuckDbTable defaultRef) [] ) )
-            , ( refToString { schemaName = "happy_path", tableName = "fact1" }, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
+            [ ( refToString dim1Ref, ( { pos = defaultPos, ref = dim1Ref }, Dimension (DuckDbTable dim1Ref) [] ) )
+            , ( refToString fact1Ref, ( { pos = defaultPos, ref = fact1Ref }, Fact (DuckDbTable fact1Ref) [] ) )
             ]
     , graph = Graph.empty
     , ref = "good_model_1"
@@ -104,16 +110,23 @@ goodModel1 =
 
 goodModel1_Expected : DimensionalModel
 goodModel1_Expected =
+    let
+        dim1Ref =
+            { schemaName = "good1", tableName = "dim1" }
+
+        fact1Ref =
+            { schemaName = "good1", tableName = "fact1" }
+    in
     { selectedDbRefs = []
     , tableInfos =
         Dict.fromList
-            [ ( refToString { schemaName = "happy_path", tableName = "dim1" }, ( { pos = defaultPos, ref = defaultRef }, Dimension (DuckDbTable defaultRef) [] ) )
-            , ( refToString { schemaName = "happy_path", tableName = "fact1" }, ( { pos = defaultPos, ref = defaultRef }, Fact (DuckDbTable defaultRef) [] ) )
+            [ ( refToString dim1Ref, ( { pos = defaultPos, ref = dim1Ref }, Dimension (DuckDbTable dim1Ref) [] ) )
+            , ( refToString fact1Ref, ( { pos = defaultPos, ref = fact1Ref }, Fact (DuckDbTable fact1Ref) [] ) )
             ]
     , graph =
         Graph.fromNodesAndEdges
-            [ Node 1 (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
-            , Node 2 (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
+            [ Node 1 (DuckDbTable dim1Ref)
+            , Node 2 (DuckDbTable fact1Ref)
             ]
             []
     , ref = "good_model_1"
@@ -122,41 +135,51 @@ goodModel1_Expected =
 
 goodModel2 : DimensionalModel
 goodModel2 =
+    let
+        dim1Ref =
+            { schemaName = "good2", tableName = "dim1" }
+
+        dim2Ref =
+            { schemaName = "good2", tableName = "dim2" }
+
+        fact1Ref =
+            { schemaName = "good2", tableName = "fact1" }
+    in
     -- Many of the values below exist purely to make the compiler happy, but some impact the behavior we're testing
     -- The fact table must join to each dimension table, col_b -> col_b, and col_d -> col_d
     { selectedDbRefs = []
     , tableInfos =
         Dict.fromList
-            [ ( refToString { schemaName = "good_2", tableName = "fact1" }
-              , ( { pos = defaultPos, ref = defaultRef }
-                , Fact (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
-                    [ Persisted_ { name = "col_a", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
-                    , Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
-                    , Persisted_ { name = "col_c", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
-                    , Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
-                    , Persisted_ { name = "col_e", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" } }
+            [ ( refToString fact1Ref
+              , ( { pos = defaultPos, ref = fact1Ref }
+                , Fact (DuckDbTable fact1Ref)
+                    [ Persisted_ { name = "col_a", dataType = "VARCHAR", parentRef = DuckDbTable fact1Ref }
+                    , Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable fact1Ref }
+                    , Persisted_ { name = "col_c", dataType = "VARCHAR", parentRef = DuckDbTable fact1Ref }
+                    , Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable fact1Ref }
+                    , Persisted_ { name = "col_e", dataType = "VARCHAR", parentRef = DuckDbTable fact1Ref }
                     ]
                 )
               )
-            , ( refToString { schemaName = "good_2", tableName = "dim1" }
-              , ( { pos = defaultPos, ref = defaultRef }
-                , Dimension (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
-                    [ Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
-                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
-                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
-                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
-                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" } }
+            , ( refToString dim1Ref
+              , ( { pos = defaultPos, ref = dim1Ref }
+                , Dimension (DuckDbTable dim1Ref)
+                    [ Persisted_ { name = "col_b", dataType = "VARCHAR", parentRef = DuckDbTable dim1Ref }
+                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable dim1Ref }
+                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable dim1Ref }
+                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable dim1Ref }
+                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable dim1Ref }
                     ]
                 )
               )
-            , ( refToString { schemaName = "good_2", tableName = "dim2" }
-              , ( { pos = defaultPos, ref = defaultRef }
-                , Dimension (DuckDbTable { schemaName = "happy_path", tableName = "dim2" })
-                    [ Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
-                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
-                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
-                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
-                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" } }
+            , ( refToString dim2Ref
+              , ( { pos = defaultPos, ref = dim2Ref }
+                , Dimension (DuckDbTable dim2Ref)
+                    [ Persisted_ { name = "col_d", dataType = "VARCHAR", parentRef = DuckDbTable dim2Ref }
+                    , Persisted_ { name = "attr_1", dataType = "VARCHAR", parentRef = DuckDbTable dim2Ref }
+                    , Persisted_ { name = "attr_2", dataType = "VARCHAR", parentRef = DuckDbTable dim2Ref }
+                    , Persisted_ { name = "attr_3", dataType = "VARCHAR", parentRef = DuckDbTable dim2Ref }
+                    , Persisted_ { name = "attr_4", dataType = "VARCHAR", parentRef = DuckDbTable dim2Ref }
                     ]
                 )
               )
@@ -169,24 +192,33 @@ goodModel2 =
 goodModel2_Expected : DimensionalModel
 goodModel2_Expected =
     let
+        dim1Ref =
+            { schemaName = "good2", tableName = "dim1" }
+
+        dim2Ref =
+            { schemaName = "good2", tableName = "dim2" }
+
+        fact1Ref =
+            { schemaName = "good2", tableName = "fact1" }
+
         nodes : List (Node DuckDbRef_)
         nodes =
-            [ Node 1 (DuckDbTable { schemaName = "happy_path", tableName = "fact1" })
-            , Node 2 (DuckDbTable { schemaName = "happy_path", tableName = "dim1" })
-            , Node 3 (DuckDbTable { schemaName = "happy_path", tableName = "dim2" })
+            [ Node 1 (DuckDbTable fact1Ref)
+            , Node 2 (DuckDbTable dim1Ref)
+            , Node 3 (DuckDbTable dim2Ref)
             ]
 
         edges : List (Edge DimensionalModelEdge)
         edges =
             [ Edge 1
                 2
-                ( Persisted_ { name = "col_b", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" }, dataType = "VARCHAR" }
-                , Persisted_ { name = "col_b", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim1" }, dataType = "VARCHAR" }
+                ( Persisted_ { name = "col_b", parentRef = DuckDbTable fact1Ref, dataType = "VARCHAR" }
+                , Persisted_ { name = "col_b", parentRef = DuckDbTable dim1Ref, dataType = "VARCHAR" }
                 )
             , Edge 1
                 3
-                ( Persisted_ { name = "col_d", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "fact1" }, dataType = "VARCHAR" }
-                , Persisted_ { name = "col_d", parentRef = DuckDbTable { schemaName = "happy_path", tableName = "dim2" }, dataType = "VARCHAR" }
+                ( Persisted_ { name = "col_d", parentRef = DuckDbTable fact1Ref, dataType = "VARCHAR" }
+                , Persisted_ { name = "col_d", parentRef = DuckDbTable dim2Ref, dataType = "VARCHAR" }
                 )
             ]
 

--- a/tests/DimensionalModelTest.elm
+++ b/tests/DimensionalModelTest.elm
@@ -26,6 +26,8 @@ suite =
                 (\_ -> naiveColumnPairingStrategy goodModel1 |> Expect.equal (Success goodModel1_Expected))
             , test "happy path - case 2"
                 (\_ -> naiveColumnPairingStrategy goodModel2 |> Expect.equal (Success goodModel2_Expected))
+
+            -- TODO: Test case with two facts with 1 or more column names that match should NOT result in joins
             ]
         ]
 

--- a/tests/UtilsTest.elm
+++ b/tests/UtilsTest.elm
@@ -2,7 +2,7 @@ module UtilsTest exposing (..)
 
 import Expect exposing (Expectation)
 import Test exposing (Test, describe, test)
-import Utils exposing (collapseWhitespace)
+import Utils exposing (cartesian, collapseWhitespace)
 
 
 suite : Test
@@ -23,5 +23,25 @@ suite =
                 (\_ -> collapseWhitespace "\t\nsome      \t space\n" True |> Expect.equal "some space")
             , test "case 3"
                 (\_ -> collapseWhitespace "\t\nsome  \n    \t space" True |> Expect.equal "some space")
+            ]
+        , describe "behavior of cartesian product utility function"
+            [ test "case 1"
+                (\_ -> cartesian [] [] |> Expect.equal [])
+            , test "case 2"
+                (\_ -> cartesian [ 1, 2, 3 ] [] |> Expect.equal [])
+            , test "case 3"
+                (\_ -> cartesian [] [ 1, 2, 3 ] |> Expect.equal [])
+            , test "case 4"
+                (\_ ->
+                    cartesian [ 'a', 'b', 'c' ] [ 1, 2 ]
+                        |> Expect.equal
+                            [ ( 'a', 1 )
+                            , ( 'a', 2 )
+                            , ( 'b', 1 )
+                            , ( 'b', 2 )
+                            , ( 'c', 1 )
+                            , ( 'c', 2 )
+                            ]
+                )
             ]
         ]


### PR DESCRIPTION
Fact and dim edges are inferred from column names to build the graph representing the dimensional model. The ability to modify this output will exist (it's my next feature to develop).

I'll need to spend a bit of time on how to test graphs well. I want to move on, but filed the first `tech debt` ticket for this project 😸 . I believe the algo works, but the tests don't yet prove it.

The PR also significantly refactors the logic for frontend/backend updating / ownership of Dimensional model data.
* backend owns the data
* backend must gather data from its local duckdbcache when user adds a table to their Dimensional Model
* frontend actions are mapped `ToBackend`, and all updates / mutations are handled by the backend, and the full dimensional model is delivered upon success

This may introduce race conditions for multiple clients editing the same model, but a user-friendly lock system on the rendered cards feels doable, so I'm not concerned with this for now.

I've also started using the `DeliveryEnvelope` pattern for backend error handling. it's similar to `WebData` in the elm/remote repo.