### PR TITLE
limit 0 for metadata queries

### DIFF
--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -115,7 +115,7 @@ update msg model =
                             let
                                 queryStr : String
                                 queryStr =
-                                    "select * from " ++ refToString r
+                                    "select * from " ++ refToString r ++ " limit 0"
                             in
                             ( { model | duckDbCache = Warming oldCache partialInProgressCache rs }
                             , queryDuckDbMeta queryStr True [ r ] Cache_GotDuckDbMetaDataResponse

--- a/src/DuckDb.elm
+++ b/src/DuckDb.elm
@@ -304,6 +304,10 @@ queryDuckDb query allowFallback refs onResponse =
 
 queryDuckDbMeta : String -> Bool -> List DuckDbRef -> (Result Error DuckDbMetaResponse -> msg) -> Cmd msg
 queryDuckDbMeta query allowFallback refs onResponse =
+    -- NB: Fetching metadata is essentially a query with 'LIMIT 0' implied.
+    --     Here, we're assuming the caller of this function is supplying such a query
+    --     This is in-lieu of SQL parsing, which when complete, can be used to enforce such
+    --     a constraint server-side.
     let
         duckDbQueryEncoder : JE.Value
         duckDbQueryEncoder =


### PR DESCRIPTION
This PR significantly speeds up cache refreshing by passing in `limit 0` to queries intended only to fetch metadata.

I've accidentally collected an important benchmark. A `.parquet` file that is 378KB going over the wire in the current JSON form has a whopping 6.7MB payload! Taking roughly 5.0-5.2 seconds per request.