### PR TITLE
abstract out button, introduce msg debugger panel

### DIFF
--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -259,6 +259,7 @@ updateFromFrontend sessionId clientId msg model =
                                             { renderInfo =
                                                 { ref = duckDbRef
                                                 , pos = { x = 100, y = 100 }
+                                                , isDrawerOpen = False
                                                 }
                                             , assignment = Unassigned (DuckDbTable duckDbRef) colDescs
                                             , isIncluded = True

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -17,6 +17,7 @@ type alias PositionPx =
 type alias CardRenderInfo =
     { pos : PositionPx
     , ref : DuckDb.DuckDbRef
+    , isDrawerOpen : Bool
     }
 
 

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -39,6 +39,7 @@ type alias DimensionalModel =
 
 
 type alias DimModelDuckDbSourceInfo =
+    -- TODO: Should I unfold CardRenderInfo into this record type?
     { renderInfo : CardRenderInfo
     , assignment : KimballAssignment DuckDbRef_ (List DuckDbColumnDescription)
     , isIncluded : Bool

--- a/src/DimensionalModel.elm
+++ b/src/DimensionalModel.elm
@@ -1,4 +1,4 @@
-module DimensionalModel exposing (CardRenderInfo, ColumnGraph, CommonRefEdge, DimModelDuckDbSourceInfo, DimensionalModel, DimensionalModelRef, EdgeLabel(..), JoinableEdge, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), addEdge, addEdges, addNode, addNodes, columnGraph2DotString, edge2Str, edgesOfType, naiveColumnPairingStrategy)
+module DimensionalModel exposing (CardRenderInfo, ColumnGraph, CommonRefEdge, DimModelDuckDbSourceInfo, DimensionalModel, DimensionalModelRef, EdgeLabel(..), JoinableEdge, KimballAssignment(..), NaivePairingStrategyResult(..), PositionPx, Reason(..), addEdge, addEdges, addNode, addNodes, columnDescFromNodeId, columnGraph2DotString, edge2Str, edgesOfType, naiveColumnPairingStrategy)
 
 import Dict exposing (Dict)
 import DuckDb exposing (DuckDbColumnDescription(..), DuckDbRef, DuckDbRefString, DuckDbRef_(..), refToString, ref_ToString)
@@ -251,6 +251,16 @@ type EdgeLabel
 
 type alias ColumnGraph =
     Graph DuckDbColumnDescription EdgeLabel
+
+
+columnDescFromNodeId : ColumnGraph -> NodeId -> Maybe DuckDbColumnDescription
+columnDescFromNodeId graph nodeId =
+    case Graph.get nodeId graph of
+        Just a ->
+            Just a.node.label
+
+        Nothing ->
+            Nothing
 
 
 columnGraph2DotString : ColumnGraph -> String

--- a/src/Evergreen/Migrate/V41.elm
+++ b/src/Evergreen/Migrate/V41.elm
@@ -1,0 +1,35 @@
+module Evergreen.Migrate.V41 exposing (..)
+
+import Evergreen.V40.Types as Old
+import Evergreen.V41.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    ModelUnchanged
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgOldValueIgnored
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgUnchanged
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgOldValueIgnored

--- a/src/Evergreen/V41/Array2D.elm
+++ b/src/Evergreen/V41/Array2D.elm
@@ -1,0 +1,15 @@
+module Evergreen.V41.Array2D exposing (..)
+
+import Array
+
+
+type alias RowIx =
+    Int
+
+
+type alias ColIx =
+    Int
+
+
+type alias Array2D e =
+    Array.Array (Array.Array e)

--- a/src/Evergreen/V41/Bridge.elm
+++ b/src/Evergreen/V41/Bridge.elm
@@ -1,0 +1,62 @@
+module Evergreen.V41.Bridge exposing (..)
+
+import Dict
+import Evergreen.V41.DimensionalModel
+import Evergreen.V41.DuckDb
+
+
+type alias DuckDbMetaDataCacheEntry =
+    { ref : Evergreen.V41.DuckDb.DuckDbRef
+    , columnDescriptions : List Evergreen.V41.DuckDb.DuckDbColumnDescription
+    }
+
+
+type alias DuckDbCache =
+    { refs : List Evergreen.V41.DuckDb.DuckDbRef
+    , metaData : Dict.Dict Evergreen.V41.DuckDb.DuckDbRefString DuckDbMetaDataCacheEntry
+    }
+
+
+type DuckDbCache_
+    = Cold DuckDbCache
+    | WarmingCycleInitiated DuckDbCache
+    | Warming DuckDbCache DuckDbCache (List Evergreen.V41.DuckDb.DuckDbRef)
+    | Hot DuckDbCache
+
+
+type alias BackendErrorMessage =
+    String
+
+
+type BackendData data
+    = NotAsked_
+    | Fetching_
+    | Success_ data
+    | Error_ BackendErrorMessage
+
+
+type DimensionalModelUpdate
+    = FullReplacement Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.DimensionalModel
+    | UpdateNodePosition Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DuckDb.DuckDbRef Evergreen.V41.DimensionalModel.PositionPx
+    | AddDuckDbRefToModel Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DuckDb.DuckDbRef
+    | ToggleIncludedNode Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DuckDb.DuckDbRef
+    | UpdateAssignment Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DuckDb.DuckDbRef (Evergreen.V41.DimensionalModel.KimballAssignment Evergreen.V41.DuckDb.DuckDbRef_ (List Evergreen.V41.DuckDb.DuckDbColumnDescription))
+    | UpdateGraph Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.ColumnGraph
+
+
+type ToBackend
+    = FetchDimensionalModelRefs
+    | CreateNewDimensionalModel Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | FetchDimensionalModel Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | UpdateDimensionalModel DimensionalModelUpdate
+    | Admin_FetchAllBackendData
+    | Admin_PingServer
+    | Admin_Task_BuildDateDimTable String String
+    | Admin_InitiateDuckDbCacheWarmingCycle
+    | Admin_PurgeBackendData
+    | Kimball_FetchDuckDbRefs
+
+
+type DeliveryEnvelope data
+    = BackendSuccess data
+    | BackendError BackendErrorMessage

--- a/src/Evergreen/V41/DimensionalModel.elm
+++ b/src/Evergreen/V41/DimensionalModel.elm
@@ -1,0 +1,62 @@
+module Evergreen.V41.DimensionalModel exposing (..)
+
+import Dict
+import Evergreen.V41.DuckDb
+import Graph
+
+
+type alias DimensionalModelRef =
+    String
+
+
+type alias PositionPx =
+    { x : Float
+    , y : Float
+    }
+
+
+type alias CardRenderInfo =
+    { pos : PositionPx
+    , ref : Evergreen.V41.DuckDb.DuckDbRef
+    , isDrawerOpen : Bool
+    }
+
+
+type KimballAssignment ref columns
+    = Unassigned ref columns
+    | Fact ref columns
+    | Dimension ref columns
+
+
+type alias DimModelDuckDbSourceInfo =
+    { renderInfo : CardRenderInfo
+    , assignment : KimballAssignment Evergreen.V41.DuckDb.DuckDbRef_ (List Evergreen.V41.DuckDb.DuckDbColumnDescription)
+    , isIncluded : Bool
+    }
+
+
+type EdgeLabel
+    = CommonRef
+    | Joinable
+
+
+type alias ColumnGraph =
+    Graph.Graph Evergreen.V41.DuckDb.DuckDbColumnDescription EdgeLabel
+
+
+type alias DimensionalModel =
+    { ref : DimensionalModelRef
+    , tableInfos : Dict.Dict Evergreen.V41.DuckDb.DuckDbRefString DimModelDuckDbSourceInfo
+    , graph : ColumnGraph
+    }
+
+
+type Reason
+    = AllInputTablesMustBeAssigned
+    | InputMustContainAtLeastOneFactTable
+    | InputMustContainAtLeastOneDimensionTable
+
+
+type NaivePairingStrategyResult
+    = Success DimensionalModel
+    | Fail Reason

--- a/src/Evergreen/V41/DuckDb.elm
+++ b/src/Evergreen/V41/DuckDb.elm
@@ -1,0 +1,98 @@
+module Evergreen.V41.DuckDb exposing (..)
+
+import ISO8601
+
+
+type alias DuckDbRefString =
+    String
+
+
+type alias SchemaName =
+    String
+
+
+type alias TableName =
+    String
+
+
+type alias DuckDbRef =
+    { schemaName : SchemaName
+    , tableName : TableName
+    }
+
+
+type DuckDbRef_
+    = DuckDbView DuckDbRef
+    | DuckDbTable DuckDbRef
+
+
+type alias ColumnName =
+    String
+
+
+type alias PersistedDuckDbColumnDescription =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    }
+
+
+type alias ComputedDuckDbColumnDescription =
+    { name : ColumnName
+    , dataType : String
+    }
+
+
+type DuckDbColumnDescription
+    = Persisted_ PersistedDuckDbColumnDescription
+    | Computed_ ComputedDuckDbColumnDescription
+
+
+type Val
+    = Varchar_ String
+    | Time_ ISO8601.Time
+    | Bool_ Bool
+    | Float_ Float
+    | Int_ Int
+    | Unknown
+
+
+type alias PersistedDuckDbColumn =
+    { name : ColumnName
+    , parentRef : DuckDbRef_
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type alias ComputedDuckDbColumn =
+    { name : ColumnName
+    , dataType : String
+    , vals : List (Maybe Val)
+    }
+
+
+type DuckDbColumn
+    = Persisted PersistedDuckDbColumn
+    | Computed ComputedDuckDbColumn
+
+
+type alias DuckDbQueryResponse =
+    { columns : List DuckDbColumn
+    }
+
+
+type alias DuckDbMetaResponse =
+    { columnDescriptions : List DuckDbColumnDescription
+    , refs : List DuckDbRef
+    }
+
+
+type alias DuckDbRefsResponse =
+    { refs : List DuckDbRef
+    }
+
+
+type alias PingResponse =
+    { message : String
+    }

--- a/src/Evergreen/V41/Element.elm
+++ b/src/Evergreen/V41/Element.elm
@@ -1,0 +1,7 @@
+module Evergreen.V41.Element exposing (..)
+
+import Evergreen.V41.Internal.Model
+
+
+type alias Color =
+    Evergreen.V41.Internal.Model.Color

--- a/src/Evergreen/V41/Gen/Model.elm
+++ b/src/Evergreen/V41/Gen/Model.elm
@@ -1,0 +1,36 @@
+module Evergreen.V41.Gen.Model exposing (..)
+
+import Evergreen.V41.Gen.Params.Admin
+import Evergreen.V41.Gen.Params.ElmUiSvgIssue
+import Evergreen.V41.Gen.Params.Home_
+import Evergreen.V41.Gen.Params.Kimball
+import Evergreen.V41.Gen.Params.NotFound
+import Evergreen.V41.Gen.Params.Sheet
+import Evergreen.V41.Gen.Params.Stories
+import Evergreen.V41.Gen.Params.Stories.Basics
+import Evergreen.V41.Gen.Params.Stories.EntityRelationshipDiagram
+import Evergreen.V41.Gen.Params.Stories.TextEditor
+import Evergreen.V41.Gen.Params.VegaLite
+import Evergreen.V41.Pages.Admin
+import Evergreen.V41.Pages.ElmUiSvgIssue
+import Evergreen.V41.Pages.Kimball
+import Evergreen.V41.Pages.Sheet
+import Evergreen.V41.Pages.Stories.Basics
+import Evergreen.V41.Pages.Stories.EntityRelationshipDiagram
+import Evergreen.V41.Pages.Stories.TextEditor
+import Evergreen.V41.Pages.VegaLite
+
+
+type Model
+    = Redirecting_
+    | Admin Evergreen.V41.Gen.Params.Admin.Params Evergreen.V41.Pages.Admin.Model
+    | ElmUiSvgIssue Evergreen.V41.Gen.Params.ElmUiSvgIssue.Params Evergreen.V41.Pages.ElmUiSvgIssue.Model
+    | Home_ Evergreen.V41.Gen.Params.Home_.Params
+    | Kimball Evergreen.V41.Gen.Params.Kimball.Params Evergreen.V41.Pages.Kimball.Model
+    | Sheet Evergreen.V41.Gen.Params.Sheet.Params Evergreen.V41.Pages.Sheet.Model
+    | Stories Evergreen.V41.Gen.Params.Stories.Params
+    | VegaLite Evergreen.V41.Gen.Params.VegaLite.Params Evergreen.V41.Pages.VegaLite.Model
+    | Stories__Basics Evergreen.V41.Gen.Params.Stories.Basics.Params Evergreen.V41.Pages.Stories.Basics.Model
+    | Stories__EntityRelationshipDiagram Evergreen.V41.Gen.Params.Stories.EntityRelationshipDiagram.Params Evergreen.V41.Pages.Stories.EntityRelationshipDiagram.Model
+    | Stories__TextEditor Evergreen.V41.Gen.Params.Stories.TextEditor.Params Evergreen.V41.Pages.Stories.TextEditor.Model
+    | NotFound Evergreen.V41.Gen.Params.NotFound.Params

--- a/src/Evergreen/V41/Gen/Msg.elm
+++ b/src/Evergreen/V41/Gen/Msg.elm
@@ -1,0 +1,21 @@
+module Evergreen.V41.Gen.Msg exposing (..)
+
+import Evergreen.V41.Pages.Admin
+import Evergreen.V41.Pages.ElmUiSvgIssue
+import Evergreen.V41.Pages.Kimball
+import Evergreen.V41.Pages.Sheet
+import Evergreen.V41.Pages.Stories.Basics
+import Evergreen.V41.Pages.Stories.EntityRelationshipDiagram
+import Evergreen.V41.Pages.Stories.TextEditor
+import Evergreen.V41.Pages.VegaLite
+
+
+type Msg
+    = Admin Evergreen.V41.Pages.Admin.Msg
+    | ElmUiSvgIssue Evergreen.V41.Pages.ElmUiSvgIssue.Msg
+    | Kimball Evergreen.V41.Pages.Kimball.Msg
+    | Sheet Evergreen.V41.Pages.Sheet.Msg
+    | VegaLite Evergreen.V41.Pages.VegaLite.Msg
+    | Stories__Basics Evergreen.V41.Pages.Stories.Basics.Msg
+    | Stories__EntityRelationshipDiagram Evergreen.V41.Pages.Stories.EntityRelationshipDiagram.Msg
+    | Stories__TextEditor Evergreen.V41.Pages.Stories.TextEditor.Msg

--- a/src/Evergreen/V41/Gen/Pages.elm
+++ b/src/Evergreen/V41/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V41.Gen.Pages exposing (..)
+
+import Evergreen.V41.Gen.Model
+import Evergreen.V41.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V41.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V41.Gen.Msg.Msg

--- a/src/Evergreen/V41/Gen/Params/Admin.elm
+++ b/src/Evergreen/V41/Gen/Params/Admin.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Admin exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/ElmUiSvgIssue.elm
+++ b/src/Evergreen/V41/Gen/Params/ElmUiSvgIssue.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.ElmUiSvgIssue exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Home_.elm
+++ b/src/Evergreen/V41/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Kimball.elm
+++ b/src/Evergreen/V41/Gen/Params/Kimball.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Kimball exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V41/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Sheet.elm
+++ b/src/Evergreen/V41/Gen/Params/Sheet.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Sheet exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Stories.elm
+++ b/src/Evergreen/V41/Gen/Params/Stories.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Stories exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Stories/Basics.elm
+++ b/src/Evergreen/V41/Gen/Params/Stories/Basics.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Stories.Basics exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Stories/EntityRelationshipDiagram.elm
+++ b/src/Evergreen/V41/Gen/Params/Stories/EntityRelationshipDiagram.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Stories.EntityRelationshipDiagram exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/Stories/TextEditor.elm
+++ b/src/Evergreen/V41/Gen/Params/Stories/TextEditor.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.Stories.TextEditor exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Gen/Params/VegaLite.elm
+++ b/src/Evergreen/V41/Gen/Params/VegaLite.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Gen.Params.VegaLite exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V41/Internal/Model.elm
+++ b/src/Evergreen/V41/Internal/Model.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Internal.Model exposing (..)
+
+
+type Color
+    = Rgba Float Float Float Float

--- a/src/Evergreen/V41/Pages/Admin.elm
+++ b/src/Evergreen/V41/Pages/Admin.elm
@@ -1,0 +1,47 @@
+module Evergreen.V41.Pages.Admin exposing (..)
+
+import Dict
+import Evergreen.V41.Bridge
+import Evergreen.V41.DimensionalModel
+import Lamdera
+
+
+type alias Model =
+    { backendModel :
+        Maybe
+            { sessionIds : List Lamdera.SessionId
+            , dimensionalModels : Dict.Dict Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.DimensionalModel
+            , duckDbCache : Evergreen.V41.Bridge.DuckDbCache_
+            }
+    , dateDimStartDate : String
+    , dateDimEndDate : String
+    , proxiedServerStatus : Maybe String
+    , purgedDataStatus : Maybe String
+    , cacheRefreshStatus : Maybe String
+    , selectedDimModel : Maybe Evergreen.V41.DimensionalModel.DimensionalModel
+    , dateDimTaskResponse : Maybe String
+    }
+
+
+type DateDimFormField
+    = StartDate
+    | EndDate
+
+
+type Msg
+    = RefetchBackendData
+    | PurgeBackendData
+    | UserClickedRefreshBackendCache
+    | ProxyServerPingToBackend
+    | UserChangedDateDimForm DateDimFormField String
+    | ProxyTask_DateDimTable String String
+    | GotTask_DateDimResponse String
+    | GotPurgeDataConfirmation String
+    | GotCacheRefreshConfirmation String
+    | GotProxiedServerPingStatus String
+    | UserClickedDimModelRow Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | GotBackendData
+        { sessionIds : List Lamdera.SessionId
+        , dimensionalModels : Dict.Dict Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.DimensionalModel
+        , duckDbCache : Evergreen.V41.Bridge.DuckDbCache_
+        }

--- a/src/Evergreen/V41/Pages/ElmUiSvgIssue.elm
+++ b/src/Evergreen/V41/Pages/ElmUiSvgIssue.elm
@@ -1,0 +1,14 @@
+module Evergreen.V41.Pages.ElmUiSvgIssue exposing (..)
+
+
+type alias Model =
+    { hoveredOnFish : Maybe Int
+    , mouseOnCard : Bool
+    }
+
+
+type Msg
+    = ReplaceMe
+    | MouseEnteredFish Int
+    | MouseEnteredCard
+    | MouseLeftCard

--- a/src/Evergreen/V41/Pages/Kimball.elm
+++ b/src/Evergreen/V41/Pages/Kimball.elm
@@ -1,0 +1,106 @@
+module Evergreen.V41.Pages.Kimball exposing (..)
+
+import Browser.Dom
+import Evergreen.V41.Bridge
+import Evergreen.V41.DimensionalModel
+import Evergreen.V41.DuckDb
+import Evergreen.V41.Ui
+import Evergreen.V41.Utils
+import Html.Events.Extra.Mouse
+import Set
+
+
+type alias LayoutInfo =
+    { mainPanelWidth : Int
+    , mainPanelHeight : Int
+    , sidePanelWidth : Int
+    , canvasElementWidth : Float
+    , canvasElementHeight : Float
+    , viewBoxXMin : Float
+    , viewBoxYMin : Float
+    , viewBoxWidth : Float
+    , viewBoxHeight : Float
+    }
+
+
+type PageRenderStatus
+    = AwaitingDomInfo
+    | Ready LayoutInfo
+
+
+type DragState
+    = Idle
+    | DragInitiated Evergreen.V41.DuckDb.DuckDbRef
+    | Dragging Evergreen.V41.DuckDb.DuckDbRef (Maybe Html.Events.Extra.Mouse.Event) Html.Events.Extra.Mouse.Event Evergreen.V41.DimensionalModel.CardRenderInfo
+
+
+type ColumnPairingOperation
+    = ColumnPairingIdle
+    | ColumnPairingListening
+    | OriginSelected Evergreen.V41.DuckDb.DuckDbColumnDescription
+    | DestinationSelected Evergreen.V41.DuckDb.DuckDbColumnDescription Evergreen.V41.DuckDb.DuckDbColumnDescription
+
+
+type CursorMode
+    = DefaultCursor
+    | ColumnPairingCursor
+
+
+type alias Model =
+    { duckDbRefs : Evergreen.V41.Bridge.BackendData (List Evergreen.V41.DuckDb.DuckDbRef)
+    , selectedTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , pageRenderStatus : PageRenderStatus
+    , hoveredOnNodeTitle : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , hoveredOnColumnWithinCard : Maybe Evergreen.V41.DuckDb.DuckDbColumnDescription
+    , partialEdgeInProgress : Maybe Evergreen.V41.DuckDb.DuckDbColumnDescription
+    , dragState : DragState
+    , mouseEvent : Maybe Html.Events.Extra.Mouse.Event
+    , viewPort : Maybe Browser.Dom.Viewport
+    , dimensionalModelRefs : Evergreen.V41.Bridge.BackendData (List Evergreen.V41.DimensionalModel.DimensionalModelRef)
+    , proposedNewModelName : String
+    , selectedDimensionalModel : Maybe Evergreen.V41.DimensionalModel.DimensionalModel
+    , pairingAlgoResult : Maybe Evergreen.V41.DimensionalModel.NaivePairingStrategyResult
+    , dropdownState : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , inspectedColumn : Maybe Evergreen.V41.DuckDb.DuckDbColumnDescription
+    , columnPairingOperation : ColumnPairingOperation
+    , downKeys : Set.Set Evergreen.V41.Utils.KeyCode
+    , theme : Evergreen.V41.Ui.ColorTheme
+    , cursorMode : CursorMode
+    }
+
+
+type SvgViewBoxTransformation
+    = Zoom Float
+    | Translation Float Float
+
+
+type Msg
+    = FetchTableRefs
+    | GotDimensionalModelRefs (List Evergreen.V41.DimensionalModel.DimensionalModelRef)
+    | GotDimensionalModel Evergreen.V41.DimensionalModel.DimensionalModel
+    | GotDuckDbTableRefsResponse (List Evergreen.V41.DuckDb.DuckDbRef)
+    | UserSelectedDimensionalModel Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | UserClickedDuckDbRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserClickedAttemptPairing Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | UserToggledCardDropDown Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserMouseEnteredNodeTitleBar Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseEnteredColumnDescRow Evergreen.V41.DuckDb.DuckDbColumnDescription
+    | UserClickedColumnRow Evergreen.V41.DuckDb.DuckDbColumnDescription
+    | UserMouseLeftNodeTitleBar
+    | ClearNodeHoverState
+    | SvgViewBoxTransform SvgViewBoxTransformation
+    | BeginNodeDrag Evergreen.V41.DuckDb.DuckDbRef
+    | DraggedAt Html.Events.Extra.Mouse.Event
+    | DragStoppedAt Html.Events.Extra.Mouse.Event
+    | TerminateDrags
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | UpdatedNewDimModelName String
+    | UserCreatesNewDimensionalModel Evergreen.V41.DimensionalModel.DimensionalModelRef
+    | NoopKimball
+    | UserClickedKimballAssignment Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DuckDb.DuckDbRef (Evergreen.V41.DimensionalModel.KimballAssignment Evergreen.V41.DuckDb.DuckDbRef_ (List Evergreen.V41.DuckDb.DuckDbColumnDescription))
+    | UserClickedNub Evergreen.V41.DuckDb.DuckDbColumnDescription
+    | UserSelectedCursorMode CursorMode

--- a/src/Evergreen/V41/Pages/Sheet.elm
+++ b/src/Evergreen/V41/Pages/Sheet.elm
@@ -1,0 +1,110 @@
+module Evergreen.V41.Pages.Sheet exposing (..)
+
+import Array
+import Browser.Dom
+import Evergreen.V41.Array2D
+import Evergreen.V41.DuckDb
+import Evergreen.V41.SheetModel
+import Evergreen.V41.Utils
+import File
+import Http
+import RemoteData
+import Set
+import Time
+
+
+type DataInspectMode
+    = SpreadSheet
+    | QueryBuilder
+
+
+type PromptMode
+    = Idle
+    | PromptInProgress String
+
+
+type alias RawPrompt =
+    ( Evergreen.V41.SheetModel.RawPromptString, ( Evergreen.V41.Array2D.RowIx, Evergreen.V41.Array2D.ColIx ) )
+
+
+type alias CurrentFrame =
+    Int
+
+
+type UiMode
+    = SheetEditor
+    | TimelineViewer CurrentFrame
+
+
+type FileUploadStatus
+    = Idle_
+    | Waiting
+    | Success_
+    | Fail
+
+
+type RenderStatus
+    = AwaitingDomInfo
+    | Ready
+
+
+type alias Model =
+    { sheet : Evergreen.V41.SheetModel.SheetEnvelope
+    , sheetMode : DataInspectMode
+    , keysDown : Set.Set Evergreen.V41.Utils.KeyCode
+    , selectedCell : Maybe Evergreen.V41.SheetModel.Cell
+    , promptMode : PromptMode
+    , submissionHistory : List RawPrompt
+    , timeline : Array.Array Timeline
+    , uiMode : UiMode
+    , duckDbResponse : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbRefsResponse
+    , userSqlText : String
+    , fileUploadStatus : FileUploadStatus
+    , nowish : Maybe Time.Posix
+    , viewport : Maybe Browser.Dom.Viewport
+    , renderStatus : RenderStatus
+    , selectedTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , file : Maybe File.File
+    , proposedCsvTargetSchemaName : String
+    , proposedCsvTargetTableName : String
+    }
+
+
+type Timeline
+    = Timeline Model
+
+
+type Msg
+    = Tick Time.Posix
+    | GotViewport Browser.Dom.Viewport
+    | GotResizeEvent Int Int
+    | KeyWentDown Evergreen.V41.Utils.KeyCode
+    | KeyReleased Evergreen.V41.Utils.KeyCode
+    | UserSelectedTableRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | ClickedCell Evergreen.V41.SheetModel.CellCoords
+    | PromptInputChanged String
+    | PromptSubmitted RawPrompt
+    | ManualDom__AttemptFocus String
+    | ManualDom__FocusResult (Result Browser.Dom.Error ())
+    | EnterTimelineViewerMode
+    | EnterSheetEditorMode
+    | QueryDuckDb String
+    | UserSqlTextChanged String
+    | GotDuckDbResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbRefsResponse)
+    | JumpToFirstFrame
+    | JumpToFrame Int
+    | JumpToLastFrame
+    | TogglePauseResume
+    | FileUpload_UserClickedSelectFile
+    | FileUpload_UserSelectedCsvFile File.File
+    | FileUpload_UserConfirmsUpload
+    | FileUpload_UploadResponded (Result Http.Error ())
+    | FileUpload_UserChangedSchemaName String
+    | FileUpload_UserChangedTableName String

--- a/src/Evergreen/V41/Pages/Stories/Basics.elm
+++ b/src/Evergreen/V41/Pages/Stories/Basics.elm
@@ -1,0 +1,20 @@
+module Evergreen.V41.Pages.Stories.Basics exposing (..)
+
+import Evergreen.V41.Ui
+
+
+type alias Model =
+    { theme : Evergreen.V41.Ui.ColorTheme
+    , isDrawerOpen : Bool
+    , isMenuHovered : Bool
+    , hoveredOnOption : Maybe Int
+    }
+
+
+type Msg
+    = Basics__UserSelectedPalette Evergreen.V41.Ui.PaletteName
+    | UserToggledDrawer
+    | MouseEnteredDropDownMenu
+    | MouseLeftDropDownMenu
+    | MouseEnteredOption Int
+    | Noop

--- a/src/Evergreen/V41/Pages/Stories/EntityRelationshipDiagram.elm
+++ b/src/Evergreen/V41/Pages/Stories/EntityRelationshipDiagram.elm
@@ -1,0 +1,25 @@
+module Evergreen.V41.Pages.Stories.EntityRelationshipDiagram exposing (..)
+
+import Evergreen.V41.DimensionalModel
+import Evergreen.V41.DuckDb
+import Evergreen.V41.Ui
+
+
+type Msg
+    = UserClickedErdCardColumn
+    | UserHoveredOverErdCardColumn
+    | UserToggledErdCardDropdown Evergreen.V41.DuckDb.DuckDbRef
+    | UserToggledDummyDropdown
+    | UserSelectedErdCardDropdownOption
+    | UserHoveredOverOption
+    | MouseEnteredErdCard
+    | MouseLeftErdCard
+    | UserClickedButton
+
+
+type alias Model =
+    { theme : Evergreen.V41.Ui.ColorTheme
+    , dimModel : Evergreen.V41.DimensionalModel.DimensionalModel
+    , msgHistory : List Msg
+    , isDummyDrawerOpen : Bool
+    }

--- a/src/Evergreen/V41/Pages/Stories/TextEditor.elm
+++ b/src/Evergreen/V41/Pages/Stories/TextEditor.elm
@@ -1,0 +1,9 @@
+module Evergreen.V41.Pages.Stories.TextEditor exposing (..)
+
+
+type alias Model =
+    {}
+
+
+type Msg
+    = ReplaceMe

--- a/src/Evergreen/V41/Pages/VegaLite.elm
+++ b/src/Evergreen/V41/Pages/VegaLite.elm
@@ -1,0 +1,45 @@
+module Evergreen.V41.Pages.VegaLite exposing (..)
+
+import Dict
+import Evergreen.V41.DuckDb
+import Evergreen.V41.QueryBuilder
+import Http
+import RemoteData
+
+
+type Position
+    = Up
+    | Middle
+    | Down
+
+
+type alias Model =
+    { duckDbForPlotResponse : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbQueryResponse
+    , duckDbMetaResponse : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbMetaResponse
+    , duckDbTableRefs : RemoteData.WebData Evergreen.V41.DuckDb.DuckDbRefsResponse
+    , selectedTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , hoveredOnTableRef : Maybe Evergreen.V41.DuckDb.DuckDbRef
+    , data :
+        { count : Int
+        , position : Position
+        }
+    , selectedColumns : Dict.Dict Evergreen.V41.QueryBuilder.ColumnRef Evergreen.V41.QueryBuilder.KimballColumn
+    , kimballCols : List Evergreen.V41.QueryBuilder.KimballColumn
+    , openedDropDown : Maybe Evergreen.V41.QueryBuilder.ColumnRef
+    }
+
+
+type Msg
+    = FetchPlotData
+    | FetchTableRefs
+    | FetchMetaDataForRef Evergreen.V41.DuckDb.DuckDbRef
+    | GotDuckDbResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbQueryResponse)
+    | GotDuckDbMetaResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbMetaResponse)
+    | GotDuckDbTableRefsResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbRefsResponse)
+    | UserSelectedTableRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseEnteredTableRef Evergreen.V41.DuckDb.DuckDbRef
+    | UserMouseLeftTableRef
+    | UserClickKimballColumnTab Evergreen.V41.QueryBuilder.KimballColumn
+    | DropDownToggled Evergreen.V41.QueryBuilder.ColumnRef
+    | DropDownSelected_Time Evergreen.V41.QueryBuilder.ColumnRef Evergreen.V41.QueryBuilder.TimeClass
+    | DropDownSelected_Agg Evergreen.V41.QueryBuilder.ColumnRef Evergreen.V41.QueryBuilder.Aggregation

--- a/src/Evergreen/V41/QueryBuilder.elm
+++ b/src/Evergreen/V41/QueryBuilder.elm
@@ -1,0 +1,37 @@
+module Evergreen.V41.QueryBuilder exposing (..)
+
+
+type alias ColumnRef =
+    String
+
+
+type Aggregation
+    = Sum
+    | Mean
+    | Median
+    | Min
+    | Max
+    | Count
+    | CountDistinct
+
+
+type Granularity
+    = Year
+    | Quarter
+    | Month
+    | Week
+    | Day
+    | Hour
+    | Minute
+
+
+type TimeClass
+    = Continuous
+    | Discrete Granularity
+
+
+type KimballColumn
+    = Dimension ColumnRef
+    | Measure Aggregation ColumnRef
+    | Time TimeClass ColumnRef
+    | Error ColumnRef

--- a/src/Evergreen/V41/Shared.elm
+++ b/src/Evergreen/V41/Shared.elm
@@ -1,0 +1,15 @@
+module Evergreen.V41.Shared exposing (..)
+
+import Evergreen.V41.Ui
+import Time
+
+
+type alias Model =
+    { zone : Time.Zone
+    , selectedTheme : Evergreen.V41.Ui.ColorTheme
+    }
+
+
+type Msg
+    = SetTimeZoneToLocale Time.Zone
+    | Shared__UserSelectedPalette Evergreen.V41.Ui.PaletteName

--- a/src/Evergreen/V41/SheetModel.elm
+++ b/src/Evergreen/V41/SheetModel.elm
@@ -1,0 +1,35 @@
+module Evergreen.V41.SheetModel exposing (..)
+
+import Evergreen.V41.Array2D
+import ISO8601
+
+
+type alias CellCoords =
+    ( Evergreen.V41.Array2D.RowIx, Evergreen.V41.Array2D.ColIx )
+
+
+type CellElement
+    = Empty
+    | String_ String
+    | Time_ ISO8601.Time
+    | Float_ Float
+    | Int_ Int
+    | Bool_ Bool
+
+
+type alias Cell =
+    ( CellCoords, CellElement )
+
+
+type alias ColumnLabel =
+    String
+
+
+type alias SheetEnvelope =
+    { data : Evergreen.V41.Array2D.Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+type alias RawPromptString =
+    String

--- a/src/Evergreen/V41/Types.elm
+++ b/src/Evergreen/V41/Types.elm
@@ -1,0 +1,81 @@
+module Evergreen.V41.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V41.Bridge
+import Evergreen.V41.DimensionalModel
+import Evergreen.V41.DuckDb
+import Evergreen.V41.Gen.Pages
+import Evergreen.V41.Shared
+import Http
+import Lamdera
+import RemoteData
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V41.Shared.Model
+    , page : Evergreen.V41.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias ServerPingStatus =
+    RemoteData.WebData Evergreen.V41.DuckDb.PingResponse
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    , dimensionalModels : Dict.Dict Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.DimensionalModel
+    , serverPingStatus : ServerPingStatus
+    , duckDbCache : Evergreen.V41.Bridge.DuckDbCache_
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V41.Shared.Msg
+    | Page Evergreen.V41.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V41.Bridge.ToBackend
+
+
+type BackendMsg
+    = BackendNoop
+    | PingServer
+    | GotPingResponse (Result Http.Error Evergreen.V41.DuckDb.PingResponse)
+    | BeginTask_BuildDateDim String String
+    | GotTaskResponse (Result Http.Error Evergreen.V41.DuckDb.PingResponse)
+    | Cache_BeginWarmingCycle
+    | Cache_ContinueCacheWarmingInProgress
+    | Cache_GotDuckDbRefsResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbRefsResponse)
+    | Cache_GotDuckDbMetaDataResponse (Result Http.Error Evergreen.V41.DuckDb.DuckDbMetaResponse)
+
+
+type ToFrontend
+    = DeliverDimensionalModelRefs (List Evergreen.V41.DimensionalModel.DimensionalModelRef)
+    | DeliverDimensionalModel (Evergreen.V41.Bridge.DeliveryEnvelope Evergreen.V41.DimensionalModel.DimensionalModel)
+    | DeliverDuckDbRefs (Evergreen.V41.Bridge.DeliveryEnvelope (List Evergreen.V41.DuckDb.DuckDbRef))
+    | Noop_Error
+    | Admin_DeliverAllBackendData
+        { sessionIds : List Lamdera.SessionId
+        , dimensionalModels : Dict.Dict Evergreen.V41.DimensionalModel.DimensionalModelRef Evergreen.V41.DimensionalModel.DimensionalModel
+        , duckDbCache : Evergreen.V41.Bridge.DuckDbCache_
+        }
+    | Admin_DeliverServerStatus String
+    | Admin_DeliverPurgeConfirmation String
+    | Admin_DeliverCacheRefreshConfirmation String
+    | Admin_DeliverTaskDateDimResponse String

--- a/src/Evergreen/V41/Ui.elm
+++ b/src/Evergreen/V41/Ui.elm
@@ -1,0 +1,24 @@
+module Evergreen.V41.Ui exposing (..)
+
+import Evergreen.V41.Element
+
+
+type alias ColorTheme =
+    { primary1 : Evergreen.V41.Element.Color
+    , primary2 : Evergreen.V41.Element.Color
+    , secondary : Evergreen.V41.Element.Color
+    , background : Evergreen.V41.Element.Color
+    , deadspace : Evergreen.V41.Element.Color
+    , white : Evergreen.V41.Element.Color
+    , gray : Evergreen.V41.Element.Color
+    , black : Evergreen.V41.Element.Color
+    , debugWarn : Evergreen.V41.Element.Color
+    , debugAlert : Evergreen.V41.Element.Color
+    , link : Evergreen.V41.Element.Color
+    }
+
+
+type PaletteName
+    = BambooBeach
+    | CoffeeRun
+    | Nitro

--- a/src/Evergreen/V41/Utils.elm
+++ b/src/Evergreen/V41/Utils.elm
@@ -1,0 +1,5 @@
+module Evergreen.V41.Utils exposing (..)
+
+
+type alias KeyCode =
+    String

--- a/src/Pages/Kimball.elm
+++ b/src/Pages/Kimball.elm
@@ -1019,18 +1019,6 @@ viewDataSourceCard model dimModelRef renderInfo kimballAssignment =
 viewCanvas : Model -> LayoutInfo -> Element Msg
 viewCanvas model layoutInfo =
     let
-        lines : List (Svg Msg)
-        lines =
-            [ S.line
-                [ SA.x1 (ST.px 428)
-                , SA.y1 (ST.px 173)
-                , SA.x2 (ST.px 725)
-                , SA.y2 (ST.px 147)
-                , SA.stroke (ST.Paint (toAvhColor model.theme.black))
-                ]
-                []
-            ]
-
         erdCardsSvgNode : List (Svg Msg)
         erdCardsSvgNode =
             let
@@ -1070,7 +1058,7 @@ viewCanvas model layoutInfo =
                 , SA.height (ST.px layoutInfo.canvasElementHeight)
                 , SA.viewBox layoutInfo.viewBoxXMin layoutInfo.viewBoxYMin layoutInfo.viewBoxWidth layoutInfo.viewBoxHeight
                 ]
-                (erdCardsSvgNode ++ lines)
+                erdCardsSvgNode
 
 
 viewControlPanel : Model -> Element Msg

--- a/src/Pages/Stories/Basics.elm
+++ b/src/Pages/Stories/Basics.elm
@@ -11,7 +11,7 @@ import Gen.Params.Stories.Basics exposing (Params)
 import Page
 import Request
 import Shared exposing (Msg(..))
-import Ui exposing (ColorTheme, PaletteName(..), dropdownMenu, themeOf)
+import Ui exposing (ColorTheme, PaletteName(..), button, dropdownMenu, themeOf)
 import Utils exposing (bool2Str)
 import View exposing (View)
 
@@ -130,28 +130,6 @@ map_ sharedMsg =
 
         Shared__UserSelectedPalette paletteName ->
             Basics__UserSelectedPalette paletteName
-
-
-type alias ButtonProps =
-    { onClick : Maybe Msg
-    , displayText : String
-    }
-
-
-button : { r | theme : ColorTheme } -> ButtonProps -> Element Msg
-button r props =
-    Input.button []
-        { onPress = props.onClick
-        , label =
-            el
-                [ Border.width 1
-                , Border.color r.theme.secondary
-                , Background.color r.theme.primary2
-                , Border.rounded 3
-                , padding 3
-                ]
-                (E.text props.displayText)
-        }
 
 
 type alias TableProps data =

--- a/src/Pages/Stories/EntityRelationshipDiagram.elm
+++ b/src/Pages/Stories/EntityRelationshipDiagram.elm
@@ -368,7 +368,7 @@ viewEntityRelationshipCard model kimballAssignment =
                 dropDownProps =
                     { isOpen = isDrawOpen
                     , widthPx = 25
-                    , heightPx = titleBarHeightPx
+                    , heightPx = titleBarHeightPx - 1
                     , onDrawerClick = UserToggledErdCardDropdown duckDbRef_
                     , onMenuMouseEnter = MouseEnteredErdCard
                     , onMenuMouseLeave = MouseLeftErdCard
@@ -394,15 +394,18 @@ viewEntityRelationshipCard model kimballAssignment =
                     , hoveredOnOption = Nothing
                     }
             in
-            row
-                [ width fill
-                , height (px titleBarHeightPx)
-                , Border.width 1
-                , Border.color model.theme.black
-                ]
-                [ E.text (refToString duckDbRef_)
-                , el [ alignRight ] <| dropdownMenu model dropDownProps
-                ]
+            el [ width fill, height fill, paddingXY 2 0 ]
+                (row
+                    [ width fill
+                    , paddingXY 3 0
+                    , height (px titleBarHeightPx)
+                    , Border.widthEach { top = 0, bottom = 2, left = 0, right = 0 }
+                    , Border.color model.theme.secondary
+                    ]
+                    [ E.text (refToString duckDbRef_)
+                    , el [ alignRight ] <| dropdownMenu model dropDownProps
+                    ]
+                )
 
         viewCardBody : Element Msg
         viewCardBody =
@@ -439,11 +442,21 @@ viewEntityRelationshipCard model kimballAssignment =
                     )
                     colDescs
                 )
+
+        cardWidthPx =
+            250
+
+        cardHeightPx =
+            -- title bar + body (depends on length) + footer / padding
+            41 + (25 * List.length colDescs) + 5
     in
     column
-        [ width (px 250)
-        , height (px 250)
+        [ width (px cardWidthPx)
+        , height (px cardHeightPx)
         , Background.color computedBackgroundColor
+        , Border.width 1
+        , Border.color model.theme.secondary
+        , Border.rounded 5
         ]
         [ viewCardTitleBar
         , viewCardBody

--- a/src/Pages/Stories/EntityRelationshipDiagram.elm
+++ b/src/Pages/Stories/EntityRelationshipDiagram.elm
@@ -18,7 +18,7 @@ import TypedSvg as S
 import TypedSvg.Attributes as SA
 import TypedSvg.Core as SC exposing (Svg)
 import TypedSvg.Types as ST
-import Ui exposing (ColorTheme, toAvhColor)
+import Ui exposing (ColorTheme, button, toAvhColor)
 import View exposing (View)
 
 
@@ -39,6 +39,7 @@ page shared req =
 type alias Model =
     { theme : ColorTheme
     , tableInfos : Dict DuckDbRefString DimModelDuckDbSourceInfo
+    , msgHistory : List Msg
     }
 
 
@@ -89,6 +90,7 @@ init shared =
                     }
                   )
                 ]
+      , msgHistory = []
       }
     , Effect.none
     )
@@ -99,14 +101,21 @@ init shared =
 
 
 type Msg
-    = ReplaceMe
+    = UserClickedErdCardColumn
+    | UserHoveredOverErdCardColumn
+    | UserOpenedErdCardDropdown
+    | UserSelectedErdCardDropdownOption
+    | UserHoveredOverErdCard
+    | UserClickedButton
 
 
 update : Msg -> Model -> ( Model, Effect Msg )
 update msg model =
     case msg of
-        ReplaceMe ->
-            ( model, Effect.none )
+        _ ->
+            ( { model | msgHistory = msg :: model.msgHistory }
+            , Effect.none
+            )
 
 
 
@@ -125,14 +134,49 @@ subscriptions model =
 view : Model -> View Msg
 view model =
     { title = "Stories - ERD"
-    , body = viewElements model
+    , body = el [ width fill, height fill, Background.color model.theme.deadspace, padding 5 ] <| viewElements model
     }
+
+
+viewDebugInfo : Model -> Element Msg
+viewDebugInfo model =
+    let
+        msg2str : Msg -> String
+        msg2str msg =
+            case msg of
+                UserClickedErdCardColumn ->
+                    "UserClickedErdCardColumn"
+
+                UserHoveredOverErdCardColumn ->
+                    "UserHoveredOverErdCardColumn"
+
+                UserOpenedErdCardDropdown ->
+                    "UserOpenedErdCardDropdown"
+
+                UserSelectedErdCardDropdownOption ->
+                    "UserSelectedErdCardDropdownOption"
+
+                UserHoveredOverErdCard ->
+                    "UserHoveredOverErdCard"
+
+                UserClickedButton ->
+                    "UserClickedButton"
+
+        viewMsg : Msg -> Element Msg
+        viewMsg msg =
+            paragraph [ padding 5 ] [ E.text (msg2str msg) ]
+    in
+    textColumn [ paddingXY 0 5 ] <|
+        [ paragraph [ Font.bold, Font.size 24 ] [ E.text "Debug info:" ]
+        , paragraph [] [ E.text "Msgs:" ]
+        ]
+            ++ List.map (\m -> viewMsg m) model.msgHistory
 
 
 viewElements : Model -> Element Msg
 viewElements model =
-    el [ width fill, height fill, Background.color model.theme.deadspace, padding 5 ] <|
-        column
+    row [ width fill, height fill ]
+        [ column
             [ height fill
             , width (px 800)
             , padding 5
@@ -140,7 +184,21 @@ viewElements model =
             , centerX
             ]
             [ viewCanvas model
+            , button model
+                { onClick = Just UserClickedButton
+                , displayText = "Click me!"
+                }
             ]
+        , column
+            [ height fill
+            , width (px 250)
+            , padding 5
+            , Background.color model.theme.background
+            , centerX
+            ]
+            [ viewDebugInfo model
+            ]
+        ]
 
 
 viewCanvas : Model -> Element Msg

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -32,7 +32,7 @@ type alias Model =
 
 init : Request -> Flags -> ( Model, Cmd Msg )
 init _ json =
-    ( Model Time.utc (themeOf Nitro)
+    ( Model Time.utc (themeOf BambooBeach)
       -- placeholder gets rewritten on the Task.perform below
     , Task.perform SetTimeZoneToLocale Time.here
     )

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -32,7 +32,7 @@ type alias Model =
 
 init : Request -> Flags -> ( Model, Cmd Msg )
 init _ json =
-    ( Model Time.utc (themeOf BambooBeach)
+    ( Model Time.utc (themeOf Nitro)
       -- placeholder gets rewritten on the Task.perform below
     , Task.perform SetTimeZoneToLocale Time.here
     )

--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -353,12 +353,17 @@ dropdownMenu r props =
                 (row [ centerY, height fill, padding 0 ]
                     [ el [ alignLeft ] <| E.text props.menuBarText
                     , el
-                        [ Border.widthEach { top = 0, bottom = 0, right = 1, left = 1 }
-                        , Border.color r.theme.secondary
-                        , height fill
+                        [ height fill
                         , alignRight
                         ]
-                        (E.text "▼")
+                        (el
+                            [ centerY
+                            , Border.color r.theme.secondary
+                            , Border.width 1
+                            ]
+                         <|
+                            E.text "▼"
+                        )
                     ]
                 )
 
@@ -375,7 +380,8 @@ dropdownMenu r props =
                 False ->
                     menuHeader
     in
-    drawer
+    -- I don't fully understand why, but wrapping in this top-level el results in a better behaved width
+    el [ width (px props.widthPx), height (px props.heightPx) ] drawer
 
 
 

--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -1,4 +1,4 @@
-module Ui exposing (ColorTheme, DropDownOption, DropDownOptionId, DropDownProps, PaletteName(..), dropdownMenu, theme, themeOf, toAvhColor)
+module Ui exposing (ButtonProps, ColorTheme, DropDownOption, DropDownOptionId, DropDownProps, PaletteName(..), button, dropdownMenu, theme, themeOf, toAvhColor)
 
 import Color as AvhColor
 import Element as E exposing (..)
@@ -380,3 +380,30 @@ dropdownMenu r props =
 
 
 -- end region: drop-down component
+-- begin region: button component
+
+
+type alias ButtonProps msg =
+    { onClick : Maybe msg
+    , displayText : String
+    }
+
+
+button : { r | theme : ColorTheme } -> ButtonProps msg -> Element msg
+button r props =
+    Input.button []
+        { onPress = props.onClick
+        , label =
+            el
+                [ Border.width 1
+                , Border.color r.theme.secondary
+                , Background.color r.theme.primary2
+                , Border.rounded 3
+                , padding 3
+                ]
+                (E.text props.displayText)
+        }
+
+
+
+-- end region: button component


### PR DESCRIPTION
After some thought, I think a good way grow Elm code is to have "componentized elm-ui elements, but Msgs should be repetitive across modules". This PR steps in that direction, introducing a sort of debugger for Msgs that are sent.
 * create `msgHistory` for story page
 * abstract out button component, use it
 * Create lines for ERD cards, with heuristics / arithmetic to determine which edges of the ErdCard to draw a given edge