### PR TITLE
restore code that shouldn't be commented out

### DIFF
--- a/vendor/elm-editor/src/Update/Function.elm
+++ b/vendor/elm-editor/src/Update/Function.elm
@@ -144,8 +144,8 @@ pasteSelection model =
                 --_ =
                 --    Debug.log "paste, (sel1, sel2)" ( sel1, sel2 )
 
-                --( newArray, removed ) =
-                --    Action.deleteSelection model.selection model.lines |> Debug.log "CUT"
+                ( newArray, removed ) =
+                    Action.deleteSelection model.selection model.lines
                 delta =
                     lengthOfLine 0 model.selectedText + sel1.column - sel2.column
             in


### PR DESCRIPTION
My previous PR removed `Debug` statements in order to keep Lamdera's compiler happy. Looks like there are some issues here, the commented out values are unused, and the naming suggests they should be. But, I should keep the code as-is, just remove the debug stuff. I accidentally commented out a line when I should've just removed the pipe to debug.log